### PR TITLE
docs: add dev workflow guide and issue-driven process to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,24 @@ Monorepo with shared lib, multiple services, and Terraform infrastructure.
 - **Branch naming:** `{type}/{short-description}` — e.g. `feat/fpl-api-collector`, `fix/s3-client-timeout`, `chore/update-deps`
 - Types mirror Conventional Commits: `feat`, `fix`, `docs`, `chore`, `test`, `refactor`, `ci`
 - Open a PR, wait for CI to pass, then merge — no direct pushes to main
+- **PRs must reference the issue:** include `Closes #<n>` in the PR body so the issue auto-closes on merge
+
+## Issue Workflow
+When given an issue number to work on:
+1. Read the issue (title, body, acceptance criteria)
+2. Confirm the dependency is satisfied before starting (see Build Order below)
+3. Branch, implement, test, open PR with `Closes #<n>` in the body
+4. After the PR merges, add a brief operational note to `docs/runbook.md` (how to run locally, common failure modes, how to backfill)
+
+## Build Order (Phase 1 dependency chain)
+Later items depend on earlier ones — don't skip ahead:
+1. **Terraform infrastructure** — S3 data lake, Lambda module, ECR module
+2. **FPL API collector** — simplest Lambda; proves the pattern end-to-end
+3. **Understat + news collectors** — can be built in parallel after #2
+4. **Validation Lambda** — needs the collector S3 paths to exist
+5. **ETL / transformation** — needs validated data
+6. **Enrichment Lambdas** — needs clean data layer
+7. **Step Functions** — wires everything together; build last
 
 ## Important: Don't...
 - Hardcode credentials anywhere (use AWS Secrets Manager)

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -1,0 +1,64 @@
+# Development Workflow
+
+Practical guide for running Phase 1 development with Claude Code.
+
+## Session Structure
+
+Each session follows this loop:
+
+```
+make test          # confirm green base
+pick one issue     # move to In Progress on board
+tell Claude: "work on issue #N"
+review the diff    # see checkpoints below
+merge PR           # issue auto-closes via "Closes #N"
+update runbook     # 5 minutes, operational notes only
+```
+
+One issue per session is a sustainable pace. Two if they're small.
+
+## What to Personally Review (Don't Just Approve)
+
+Three moments where you need to actually read and think:
+
+**1. Pydantic data models**
+When Claude writes the `Player`, `Fixture`, or `GameweekPick` models, open the real FPL API endpoint in your browser and compare field names directly. Claude can get these subtly wrong without live API data.
+
+**2. Prompt templates**
+Read every `v1/` prompt before it goes in. They're the creative core — Claude writes reasonable first drafts but tighten them yourself. Check: does it ask for what you actually want? Is the output schema correct?
+
+**3. Step Functions definition**
+Trace through the state machine mentally before merging. Verify that error paths (DLQ routing, retry logic) make sense for your use case, not just that they're syntactically valid.
+
+## Parallelising with Multiple Agents
+
+Default: **one agent per PR**. Keeps context focused and PRs clean.
+
+OK to parallelise when two tasks are genuinely independent (no shared files):
+- Terraform modules + unit tests for an existing Lambda
+- Two collectors that don't share code
+
+Don't over-parallelise — a messy PR is worse than a slow one.
+
+## Post-Merge Runbook Updates
+
+After each PR merges, add a section to `docs/runbook.md`:
+- How to invoke the Lambda locally
+- Common failure modes and how to diagnose
+- How to backfill if the Lambda missed a gameweek
+
+Claude Code can write this as a follow-up commit: "update runbook for #N".
+
+## GitHub Project Board
+
+Board lives at: `github.com/users/ikuzuki/projects`  
+Columns: Backlog → To Do → In Progress → Review → Done
+
+If the board is missing, create it manually:
+1. Go to `github.com/ikuzuki/fpl-platform` → Projects tab
+2. Link a project → New project → Board template → "FPL Platform"
+3. Bulk-add existing issues via "Add item" → search by repo
+
+## FPL Gameweek Cadence
+
+Use the weekly gameweek deadline as a forcing function — run the pipeline end-to-end before each deadline to catch failures before they matter.


### PR DESCRIPTION
## Summary

- Adds `docs/workflow.md` — human-facing reference for Phase 1 session structure, build dependency order, review checkpoints (data models, prompts, Step Functions), and parallelisation rules
- Updates `CLAUDE.md` with two new sections:
  - **Issue Workflow** — read issue → check dependency → build → PR with `Closes #N` → update runbook
  - **Build Order** — infra → collectors → validation → enrichment → Step Functions dependency chain

## Test plan

- [ ] Verify `CLAUDE.md` renders correctly on GitHub
- [ ] Verify `docs/workflow.md` renders correctly on GitHub
- [ ] Confirm no existing sections in `CLAUDE.md` were accidentally modified