### PR TITLE
fix(infra): S3 lifecycle rule ordering and ECR repo naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Lambda module: log retention 14d → 30d, default memory 256 → 512 MB
 - S3 data lake module: added raw/ prefix expiration at 90 days
 
+### Fixed
+- S3 data lake lifecycle: transition days (30) now less than expiration days (90) to satisfy AWS API constraint
+- S3 data lake lifecycle rules now conditional (`enable_data_lake_lifecycle`) so non-data-lake buckets skip raw/dlq rules
+- ECR repo naming order matches deploy.yml convention (`fpl-{name}-{env}` not `fpl-{env}-{name}`)
+- Dev environment now creates 3 ECR repos (data, enrich, agent) matching the per-service deploy matrix
+
 ## [0.1.0] - 2026-04-04
 
 ### Added

--- a/infrastructure/environments/dev/main.tf
+++ b/infrastructure/environments/dev/main.tf
@@ -31,11 +31,23 @@ provider "aws" {
 }
 
 # -----------------------------------------------------------------------------
-# ECR Repository
+# ECR Repositories (one per service — matches deploy.yml naming: fpl-{name}-dev)
 # -----------------------------------------------------------------------------
-module "ecr" {
+module "ecr_data" {
   source      = "../../modules/ecr"
-  name        = "platform"
+  name        = "data"
+  environment = var.environment
+}
+
+module "ecr_enrich" {
+  source      = "../../modules/ecr"
+  name        = "enrich"
+  environment = var.environment
+}
+
+module "ecr_agent" {
+  source      = "../../modules/ecr"
+  name        = "agent"
   environment = var.environment
 }
 
@@ -48,9 +60,10 @@ module "data_lake" {
 }
 
 module "cost_reports" {
-  source      = "../../modules/s3-data-lake"
-  name        = "cost-reports"
-  environment = var.environment
+  source                     = "../../modules/s3-data-lake"
+  name                       = "cost-reports"
+  environment                = var.environment
+  enable_data_lake_lifecycle = false
 }
 
 # -----------------------------------------------------------------------------

--- a/infrastructure/modules/ecr/main.tf
+++ b/infrastructure/modules/ecr/main.tf
@@ -1,5 +1,5 @@
 resource "aws_ecr_repository" "this" {
-  name                 = "${var.project}-${var.environment}-${var.name}"
+  name                 = "${var.project}-${var.name}-${var.environment}"
   image_tag_mutability = "IMMUTABLE"
 
   image_scanning_configuration {

--- a/infrastructure/modules/s3-data-lake/README.md
+++ b/infrastructure/modules/s3-data-lake/README.md
@@ -26,6 +26,7 @@ module "data_lake" {
 | project | Project name | string | "fpl" |
 | environment | Deployment environment | string | - |
 | name | Bucket purpose name (e.g. 'data-lake', 'cost-reports') | string | "data-lake" |
+| enable_data_lake_lifecycle | Enable raw/dlq lifecycle rules | bool | true |
 
 ## Outputs
 

--- a/infrastructure/modules/s3-data-lake/main.tf
+++ b/infrastructure/modules/s3-data-lake/main.tf
@@ -30,6 +30,7 @@ resource "aws_s3_bucket_public_access_block" "data_lake" {
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "data_lake" {
+  count  = var.enable_data_lake_lifecycle ? 1 : 0
   bucket = aws_s3_bucket.data_lake.id
 
   rule {
@@ -41,7 +42,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "data_lake" {
     }
 
     transition {
-      days          = 90
+      days          = 30
       storage_class = "STANDARD_IA"
     }
 

--- a/infrastructure/modules/s3-data-lake/variables.tf
+++ b/infrastructure/modules/s3-data-lake/variables.tf
@@ -14,3 +14,9 @@ variable "name" {
   type        = string
   default     = "data-lake"
 }
+
+variable "enable_data_lake_lifecycle" {
+  description = "Enable raw/ transition/expiration and dlq/ expiration lifecycle rules. Set to false for non-data-lake buckets."
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
## Summary
- S3 lifecycle: transition raw/ at 30 days, expire at 90 days (AWS requires expiration > transition)
- S3 lifecycle rules now conditional (`enable_data_lake_lifecycle = false` for cost-reports bucket)
- ECR naming order fixed to `fpl-{name}-{env}` matching deploy.yml convention
- Dev environment creates 3 ECR repos (data, enrich, agent) instead of 1 monolithic repo

## Why
`terraform apply` failed with two errors:
1. `InvalidArgument: 'Days' in the Expiration action must be greater than 'Days' in the Transition action` — both were 90
2. Cost-reports bucket failed creating lifecycle rules for raw/dlq prefixes it doesn't use

Additionally, deploy.yml pushes to `fpl-data-dev` / `fpl-enrich-dev` / `fpl-agent-dev` but only a single `fpl-dev-platform` repo existed.

## Testing
- `terraform validate` passes on s3-data-lake, ecr modules and environments/dev
- `terraform fmt -check` clean

Closes #19