### PR TITLE
chore: add venv setup and update Makefile

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,14 @@ Monorepo with shared lib, multiple services, and Terraform infrastructure.
 - `web/` — Portfolio site + Streamlit dashboard
 - `docs/adr/` — Architecture Decision Records
 
+## Python Environment
+- **Venv location:** `venv/` (project root)
+- **Activate before any Python command:** `source /c/Users/IsseiKuzuki/fpl-platform/venv/Scripts/activate`
+- Shell state does not persist between tool calls — prefix every `pytest`, `make`, `pip`, or `python` command with the activate command above
+- Install new packages with `pip install` while venv is active — they go into `venv/` automatically
+- If adding a permanent dependency, also add it to the relevant `pyproject.toml`
+- Use `--index-url https://pypi.org/simple/` if pip defaults to a private index
+
 ## Build & Test Commands
 - Install all deps: `make install`
 - Lint: `make lint` (runs ruff check + mypy)

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
 .PHONY: install lint format test test-unit test-integration test-service clean check
 
 install:
-	uv pip install --system -e ".[dev]"
-	uv pip install --system -e libs/
+	pip install -e ".[dev]"
+	pip install -e libs/
+	pip install -e services/data/
+	pip install -e services/enrich/
 	pre-commit install
 
 lint:


### PR DESCRIPTION
## Summary
- Add Python Environment section to CLAUDE.md with venv activation instructions
- Update Makefile `install` target: `pip install` instead of `uv pip install --system`, include service packages

## Why
Claude Code agents need to activate the venv before running Python commands. Each shell call starts fresh, so CLAUDE.md documents the activation prefix pattern for all conversations.

## Testing
- N/A (docs + build config only)