### PR TITLE
feat(enrich): Langfuse observability and ECR tag mutability fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Langfuse observability: `@observe` decorators on `_call_llm` and enrichment handler for LLM call tracing
+- `EnrichSettings` config class extending `FPLSettings` with Langfuse and Anthropic credentials
 - Four concrete enrichers: PlayerSummaryEnricher, InjurySignalEnricher, SentimentEnricher, FixtureOutlookEnricher
 - Pydantic output models for all enricher outputs (structured validation)
 - Enrichment Lambda handler with Secrets Manager integration, cost tracking, and fallback handling
@@ -24,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - S3 data lake module: added raw/ prefix expiration at 90 days
 
 ### Fixed
+- ECR module: tag mutability now configurable (default MUTABLE) — fixes deploy failure where `:latest` push was rejected by IMMUTABLE policy
 - S3 data lake lifecycle: transition days (30) now less than expiration days (90) to satisfy AWS API constraint
 - S3 data lake lifecycle rules now conditional (`enable_data_lake_lifecycle`) so non-data-lake buckets skip raw/dlq rules
 - ECR repo naming order matches deploy.yml convention (`fpl-{name}-{env}` not `fpl-{env}-{name}`)

--- a/infrastructure/modules/ecr/README.md
+++ b/infrastructure/modules/ecr/README.md
@@ -1,6 +1,6 @@
 # ECR Module
 
-Creates an ECR repository with immutable tags, scan on push, and a lifecycle policy to retain the last 10 images.
+Creates an ECR repository with configurable tag mutability, scan on push, and a lifecycle policy to retain the last 10 images.
 
 ## Usage
 
@@ -18,6 +18,7 @@ module "data_repo" {
 |------|-------------|------|---------|
 | name | Repository name | string | - |
 | environment | Deployment environment | string | - |
+| image_tag_mutability | Tag mutability (MUTABLE for dev, IMMUTABLE for prod) | string | "MUTABLE" |
 
 ## Outputs
 

--- a/infrastructure/modules/ecr/main.tf
+++ b/infrastructure/modules/ecr/main.tf
@@ -1,6 +1,6 @@
 resource "aws_ecr_repository" "this" {
   name                 = "${var.project}-${var.name}-${var.environment}"
-  image_tag_mutability = "IMMUTABLE"
+  image_tag_mutability = var.image_tag_mutability
 
   image_scanning_configuration {
     scan_on_push = true

--- a/infrastructure/modules/ecr/variables.tf
+++ b/infrastructure/modules/ecr/variables.tf
@@ -13,3 +13,14 @@ variable "environment" {
   description = "Deployment environment (dev/prod)"
   type        = string
 }
+
+variable "image_tag_mutability" {
+  description = "Tag mutability setting (MUTABLE allows :latest overwrite, IMMUTABLE for prod)"
+  type        = string
+  default     = "MUTABLE"
+
+  validation {
+    condition     = contains(["MUTABLE", "IMMUTABLE"], var.image_tag_mutability)
+    error_message = "Must be MUTABLE or IMMUTABLE."
+  }
+}

--- a/services/enrich/src/fpl_enrich/config.py
+++ b/services/enrich/src/fpl_enrich/config.py
@@ -1,0 +1,21 @@
+"""Enrichment service configuration extending base FPL settings."""
+
+from functools import lru_cache
+
+from fpl_lib.core.config import FPLSettings
+
+
+class EnrichSettings(FPLSettings):
+    """Settings for the enrichment service, including Langfuse credentials."""
+
+    LANGFUSE_PUBLIC_KEY: str = ""
+    LANGFUSE_SECRET_KEY: str = ""
+    ANTHROPIC_API_KEY: str = ""
+    COST_BUCKET: str = "fpl-data-lake-dev"
+    PROMPT_VERSION: str = "v1"
+
+
+@lru_cache
+def get_enrich_settings() -> EnrichSettings:
+    """Return cached enrichment settings instance."""
+    return EnrichSettings()

--- a/services/enrich/src/fpl_enrich/enrichers/base.py
+++ b/services/enrich/src/fpl_enrich/enrichers/base.py
@@ -7,6 +7,7 @@ from collections.abc import Iterator
 from typing import Any
 
 import anthropic
+from langfuse import observe
 
 logger = logging.getLogger(__name__)
 
@@ -65,11 +66,20 @@ class FPLEnricher(ABC):
         self._log_summary()
         return results
 
+    @observe(name="enricher_batch_call")
     def _call_llm(self, batch: list[dict[str, Any]]) -> list[dict[str, Any]]:
         """Send a batch of items to the Anthropic API and parse the JSON response."""
         user_content = "\n".join(f"I{i + 1}: {json.dumps(item)}" for i, item in enumerate(batch))
 
         system_prompt = self._get_system_prompt().format(batch_size=len(batch))
+
+        logger.info(
+            "%s: calling %s with batch_size=%d, prompt_version=%s",
+            self.__class__.__name__,
+            self.MODEL,
+            len(batch),
+            self.prompt_version,
+        )
 
         response = self.client.messages.create(
             model=self.MODEL,

--- a/services/enrich/src/fpl_enrich/handlers/enricher.py
+++ b/services/enrich/src/fpl_enrich/handlers/enricher.py
@@ -6,6 +6,7 @@ from typing import Any
 import anthropic
 import boto3
 import pyarrow as pa
+from langfuse import observe
 
 from fpl_enrich.enrichers.fixture_outlook import FixtureOutlookEnricher
 from fpl_enrich.enrichers.injury_signal import InjurySignalEnricher
@@ -80,6 +81,21 @@ def _read_cached_summaries(
     return table.to_pydict()
 
 
+def _init_langfuse(region: str = "eu-west-2") -> None:
+    """Initialise Langfuse with keys from Secrets Manager."""
+    import os
+
+    if not os.environ.get("LANGFUSE_PUBLIC_KEY"):
+        os.environ["LANGFUSE_PUBLIC_KEY"] = _get_secret(
+            "/fpl-platform/dev/langfuse-public-key", region
+        )
+    if not os.environ.get("LANGFUSE_SECRET_KEY"):
+        os.environ["LANGFUSE_SECRET_KEY"] = _get_secret(
+            "/fpl-platform/dev/langfuse-secret-key", region
+        )
+
+
+@observe(name="enrich_gameweek")
 async def main(
     season: str,
     gameweek: int,
@@ -88,6 +104,7 @@ async def main(
     prompt_version: str = "v1",
 ) -> dict[str, Any]:
     """Run all enrichers on clean player data and write results to S3."""
+    logger.info("Starting enrichment for %s GW%d", season, gameweek)
     s3_client = S3Client()
 
     # Read clean player data
@@ -168,6 +185,7 @@ async def main(
 
 def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
     """AWS Lambda entry point for enrichment."""
+    _init_langfuse()
     return RunHandler(
         main_func=main,
         required_main_params=["season", "gameweek"],


### PR DESCRIPTION
## What
- Langfuse v4 `@observe` decorators on `_call_llm` (base enricher) and `main` (enrichment handler) for LLM call tracing
- `EnrichSettings` config class extending `FPLSettings` with Langfuse and Anthropic credentials
- Handler initialises Langfuse keys from Secrets Manager on Lambda cold start
- ECR module: `image_tag_mutability` now configurable (default `MUTABLE`)

## Why
Every LLM call must be traced per project rules (`.claude/rules/llm-enrichment.md`). Langfuse gives us per-call visibility into token usage, latency, and output quality across enrichment runs.

The ECR fix addresses a deploy failure where the `:latest` tag push was rejected by the `IMMUTABLE` policy — dev needs `MUTABLE` to overwrite `:latest` on each deploy.

## How
- `from langfuse import observe` (v4 API — `langfuse.decorators` was removed in v4)
- `@observe(name="enricher_batch_call")` wraps each LLM call as a traced span
- `@observe(name="enrich_gameweek")` wraps the full enrichment pipeline
- `_init_langfuse()` reads keys from Secrets Manager and sets env vars before first trace
- ECR module uses `var.image_tag_mutability` instead of hardcoded `"IMMUTABLE"`

## Testing
- 48 unit tests passing (`pytest services/enrich/tests/ -m unit`)
- `ruff check` + `ruff format --check` clean
- `terraform fmt -check` clean
- Langfuse decorators are no-ops when keys aren't configured (safe for unit tests)