### PR TITLE
docs: Phase 1 architecture decision records (ADR-0003 to ADR-0007)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Lambda module: optional `execution_role_arn` for shared external role support
 - S3 data lake module: configurable `name` variable for multi-bucket reuse
 - Step Functions module: CloudWatch log group with execution logging
+- ADR-0003: Direct Anthropic API over LangChain
+- ADR-0004: Tiered LLM model selection and batch processing (Haiku vs Sonnet, batch sizes)
+- ADR-0005: Prompt versioning by directory
+- ADR-0006: S3 prefix-based idempotency
+- ADR-0007: Container images for Lambda over zip packages
 
 ### Changed
 - Lambda module: log retention 14d → 30d, default memory 256 → 512 MB

--- a/docs/adr/0003-direct-api-over-langchain.md
+++ b/docs/adr/0003-direct-api-over-langchain.md
@@ -1,0 +1,27 @@
+# ADR-0003: Direct Anthropic API over LangChain
+
+## Status
+Accepted
+
+## Context
+The enrichment pipeline makes structured LLM calls (player summaries, injury signals, sentiment, fixture outlook). LangChain is the most popular Python framework for LLM orchestration and offers chains, output parsers, and retry logic out of the box. We needed to decide whether to use it or call the Anthropic API directly.
+
+## Decision
+Use the `anthropic` Python SDK directly for all LLM calls. No LangChain anywhere in the pipeline.
+
+## Consequences
+**Easier:**
+- Full control over prompt formatting, batching, and retry logic — no fighting framework abstractions
+- Simpler dependency tree — `anthropic` is one package vs LangChain's 20+ transitive dependencies
+- Token counting and cost tracking are straightforward from `response.usage`
+- Easier to debug — no hidden prompt wrapping or chain-of-responsibility indirection
+- Structured JSON output validated with Pydantic directly, not LangChain's output parsers
+- Smaller Lambda container images (fewer deps = faster cold starts)
+
+**Harder:**
+- We built our own batching (`FPLEnricher` base class) and retry logic instead of using LangChain's built-in
+- If we add new LLM providers, we'd need to write our own abstraction (LangChain provides this)
+- No built-in support for chains or multi-step reasoning (not needed for our enrichment use case)
+
+## Notes
+The LangGraph agent (`services/agent/`) is a separate concern — it uses LangGraph for the agentic recommendation graph, which is a different pattern from the batch enrichment pipeline.

--- a/docs/adr/0004-tiered-llm-models-and-batching.md
+++ b/docs/adr/0004-tiered-llm-models-and-batching.md
@@ -1,0 +1,36 @@
+# ADR-0004: Tiered LLM Model Selection and Batch Processing
+
+## Status
+Accepted
+
+## Context
+The enrichment pipeline runs four enrichers per gameweek across ~700 players. LLM API costs scale with token volume, and different tasks have different complexity requirements. We needed to decide which models to use and how to batch items to optimise cost vs quality.
+
+## Decision
+Use Haiku for simple classification tasks and Sonnet for complex reasoning. Batch multiple items per LLM call where quality allows.
+
+| Enricher | Model | Batch Size | Reasoning |
+|----------|-------|-----------|-----------|
+| Player Summary | claude-haiku-4-5 | 3 | Form summarisation is templated; moderate context per player |
+| Injury Signal | claude-haiku-4-5 | 5 | Binary classification (injured/not); minimal reasoning needed |
+| Sentiment | claude-haiku-4-5 | 5 | Simple sentiment scoring; bulk-friendly |
+| Fixture Outlook | claude-sonnet-4-6 | 1 | Requires reasoning about fixture runs, team strength, and schedule — needs deeper analysis |
+
+All calls use `max_tokens=4096` and return structured JSON arrays validated with Pydantic.
+
+## Cost estimate (per gameweek, ~700 players)
+- Haiku calls: ~234 batched calls (3 enrichers) at ~$0.25/MTok in, $1.25/MTok out
+- Sonnet calls: ~700 individual calls at ~$3/MTok in, $15/MTok out
+- Fixture outlook dominates cost — batch size of 1 is the tradeoff for reasoning quality
+
+## Consequences
+**Easier:**
+- Haiku keeps bulk enrichment cheap (~$0.10-0.30 per gameweek for 3 enrichers)
+- Batching amortises per-call overhead and reduces total API calls by 3-5x
+- Cost report per gameweek enables tracking and alerting on spend drift
+- Langfuse tracing attributes cost to each enricher type
+
+**Harder:**
+- Fixture outlook is expensive relative to others — may need caching or reducing to top-N players
+- Batch size tuning is empirical — too large degrades output quality, too small wastes API calls
+- Model version pinning means manual updates when new model versions release

--- a/docs/adr/0005-prompt-versioning-by-directory.md
+++ b/docs/adr/0005-prompt-versioning-by-directory.md
@@ -1,0 +1,40 @@
+# ADR-0005: Prompt Versioning by Directory
+
+## Status
+Accepted
+
+## Context
+LLM prompts are a critical part of the enrichment pipeline. Prompt changes can silently alter output quality, break downstream validation, or shift cost profiles. We needed a strategy for versioning prompts that supports iteration without risking production stability.
+
+## Decision
+Store prompt templates as plain text files in versioned directories: `services/enrich/src/fpl_enrich/prompts/v{N}/`. Each enricher loads its prompt at runtime via `load_prompt(enricher_name, version)`.
+
+```
+prompts/
+  v1/
+    player_summary.txt
+    injury_signal.txt
+    sentiment.txt
+    fixture_outlook.txt
+  v2/
+    ...
+```
+
+## Rules
+- Never edit a published version directory — create a new `v{N+1}` instead
+- The `prompt_version` parameter is passed through the Lambda event, defaulting to `"v1"`
+- Prompts are plain text with `{batch_size}` and `{batch_items}` placeholders — no Jinja or complex templating
+- Each prompt specifies its expected JSON output schema inline
+
+## Consequences
+**Easier:**
+- A/B testing: run v1 and v2 side by side by passing different `prompt_version` values
+- Rollback: revert to previous version without code changes
+- Auditability: git history shows exactly what changed between versions
+- Langfuse traces include `prompt_version` metadata for quality comparison
+- No code changes needed to iterate on prompts — just add a new directory
+
+**Harder:**
+- No compile-time validation that prompt placeholders match code expectations
+- Directory proliferation over time (mitigated: old versions can be archived)
+- Prompt and code must stay in sync — a new output field requires both a prompt change and a validator update

--- a/docs/adr/0006-s3-prefix-idempotency.md
+++ b/docs/adr/0006-s3-prefix-idempotency.md
@@ -1,0 +1,35 @@
+# ADR-0006: S3 Prefix-Based Idempotency
+
+## Status
+Accepted
+
+## Context
+Data collectors and transformers are invoked by Step Functions, which retries on failure. Without idempotency, retries produce duplicate files in S3. We needed a mechanism to detect "already done" and skip re-processing.
+
+Options considered:
+1. **DynamoDB state table** — write a record on completion, check before starting
+2. **S3 prefix existence check** — list objects under the output prefix, skip if non-empty
+3. **Lambda destination deduplication** — use request IDs to prevent re-execution
+
+## Decision
+Use S3 prefix existence checks. Before each collect/transform operation, call `s3_client.list_objects(bucket, prefix)` — if files exist, return early with `records_collected=0`.
+
+```python
+if not force and self._output_exists(prefix):
+    return CollectionResponse(status="success", records_collected=0, output_path=prefix)
+```
+
+A `force=True` parameter overrides the check for backfills.
+
+## Consequences
+**Easier:**
+- No additional infrastructure — S3 is already the data store
+- S3 is the single source of truth: if the file is there, the work is done
+- Hive-style partitioning (`season={s}/gameweek={gw}/`) makes prefix checks natural
+- Simple to reason about: "data exists = done"
+- `force=True` provides an escape hatch for re-processing
+
+**Harder:**
+- Partial writes: if a collector writes 3 of 4 files and fails, the prefix check sees it as "done" — the `force` flag handles this but requires manual intervention
+- `list_objects` adds latency (~50-100ms) per check — acceptable for our Lambda execution model
+- Not suitable for high-concurrency scenarios (no locking) — fine for our scheduled, sequential pipeline

--- a/docs/adr/0007-container-images-for-lambda.md
+++ b/docs/adr/0007-container-images-for-lambda.md
@@ -1,0 +1,35 @@
+# ADR-0007: Container Images for Lambda over Zip Packages
+
+## Status
+Accepted
+
+## Context
+AWS Lambda supports two deployment models: zip packages (up to 250 MB uncompressed) and container images (up to 10 GB). Our services depend on PyArrow, pandas, numpy, and the Anthropic SDK — heavy packages that push against zip size limits.
+
+## Decision
+Deploy all Lambda functions as container images via ECR. Each service has a multi-stage Dockerfile:
+1. **Builder stage** — installs dependencies with pip
+2. **Runtime stage** — copies installed packages into the AWS Lambda Python base image
+
+```dockerfile
+FROM public.ecr.aws/lambda/python:3.11 AS builder
+# ... install deps ...
+
+FROM public.ecr.aws/lambda/python:3.11
+COPY --from=builder /var/lang/lib/python3.11/site-packages /var/lang/lib/python3.11/site-packages
+```
+
+One ECR repository per service (`fpl-data-dev`, `fpl-enrich-dev`, `fpl-agent-dev`), with immutable tags and a lifecycle policy retaining the last 10 images.
+
+## Consequences
+**Easier:**
+- No size constraints — PyArrow + pandas + numpy alone exceed 250 MB
+- Identical local and deployed environments (same Docker image)
+- Multi-stage builds keep final image lean
+- `docker build && docker push` is simpler than managing Lambda layers
+- Immutable tags ensure deployed code is reproducible
+
+**Harder:**
+- Cold start is slower (~2-5s) compared to zip (~1-2s) — acceptable for our batch pipeline (not user-facing)
+- ECR storage cost (minimal — lifecycle policy keeps only 10 images)
+- Local testing requires Docker (vs zip which can run with just `python`)


### PR DESCRIPTION
## Summary
- **ADR-0003**: Direct Anthropic API over LangChain — why we use the `anthropic` SDK directly
- **ADR-0004**: Tiered LLM model selection — Haiku for classification, Sonnet for reasoning, with batch size rationale
- **ADR-0005**: Prompt versioning by directory — `prompts/v{N}/` pattern for A/B testing and rollback
- **ADR-0006**: S3 prefix-based idempotency — `list_objects` check instead of DynamoDB state table
- **ADR-0007**: Container images for Lambda — multi-stage Docker over zip packages

## Why
ADR-0003 was already referenced in CLAUDE.md but didn't exist. The other four document key Phase 1 decisions that someone reviewing the project would question (model selection, deployment model, idempotency strategy, prompt management).

## Testing
N/A — documentation only