### PR TITLE
docs: improve ADRs with alternatives considered, add data lake and Langfuse ADRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ADR-0005: Prompt versioning by directory
 - ADR-0006: S3 prefix-based idempotency
 - ADR-0007: Container images for Lambda over zip packages
+- ADR-0008: S3 data lake layer design (raw/clean/enriched/curated, Hive partitioning, Parquet+zstd)
+- ADR-0009: Langfuse for LLM observability
+
+### Changed
+- ADR-0001 through ADR-0007: added dates, Options Considered sections, project-specific context, and addressed edge cases
 
 ### Changed
 - Lambda module: log retention 14d → 30d, default memory 256 → 512 MB

--- a/docs/adr/0001-monorepo-architecture.md
+++ b/docs/adr/0001-monorepo-architecture.md
@@ -3,28 +3,44 @@
 ## Status
 Accepted
 
+## Date
+2026-04-04
+
 ## Context
-The FPL platform consists of 4 projects (data pipeline, recommendation agent, historical processing, live streaming) plus shared infrastructure, a shared Python library, and web frontends. We needed to decide between a single monorepo or multiple separate repositories.
+The FPL platform consists of multiple services (data pipeline, LLM enrichment, recommendation agent, streaming, ETL) plus shared infrastructure, a shared Python library, and web frontends. We needed to decide how to organise the code.
+
+This is a solo portfolio project designed to demonstrate end-to-end data + ML engineering. Hiring managers and reviewers will clone and explore it. The shared library (`fpl_lib`) changes frequently during early development as patterns stabilise.
+
+## Options Considered
+
+### 1. Monorepo (chosen)
+Single `fpl-platform` repository with directory separation (`libs/`, `services/`, `infrastructure/`, `web/`). CI uses `dorny/paths-filter` to scope jobs to changed paths.
+
+### 2. Multi-repo (rejected)
+Separate repos per service (`fpl-data`, `fpl-enrich`, `fpl-agent`, `fpl-infra`, etc.) with `fpl-lib` published as a private PyPI package.
+
+**Rejected because:**
+- Publishing `fpl_lib` as a package adds friction during early development when the shared interface is still evolving — every change requires a version bump, publish, and pin update across consumers
+- Reviewers would need to clone 6+ repos to understand the full system
+- Cross-repo CI coordination (ensuring compatible versions) adds complexity with no team to justify it
+
+### 3. Polyrepo with git submodules (rejected)
+Multiple repos linked via submodules for the shared library.
+
+**Rejected because:** Submodules are notoriously painful for solo development — easy to get into detached HEAD states, and they add git ceremony without solving the versioning problem.
 
 ## Decision
-Use a single `fpl-platform` monorepo with clear directory separation:
-- `libs/` for shared Python code
-- `services/` for each service (data, enrich, etl, agent, stream)
-- `infrastructure/` for all Terraform
-- `web/` for frontend applications
-- `docs/` for documentation
-
-CI uses `dorny/paths-filter` to only run jobs when relevant paths change.
+Use a single monorepo with clear directory separation. CI path filtering ensures only relevant jobs run on each change.
 
 ## Consequences
 **Easier:**
-- One place to clone and explore — simpler for anyone reviewing the project
+- One clone to explore the full system — critical for a portfolio project reviewed by hiring managers
+- Shared code (`libs/fpl_lib/`) is directly importable without publishing packages
 - Unified commit history showing iterative progress across all components
-- Shared code (`libs/`) directly importable without publishing packages
 - Single CI config, single project board, single set of branch protections
-- No cross-repo version pinning or dependency management
+- `dorny/paths-filter` pattern is proven (used at Intech) and keeps CI fast despite monorepo scale
 
 **Harder:**
-- If this grew into a team project, the monorepo could become unwieldy
-- CI needs path filtering to avoid running all jobs on every change
-- A completely unrelated project (different domain) would warrant its own repo
+- If this grew into a team project, the monorepo could become unwieldy without tooling (Nx, Turborepo)
+- CI path filtering adds configuration complexity vs per-repo triggers
+- All services share the same branch protection rules (can't have stricter rules for infra vs data)

--- a/docs/adr/0002-terraform-over-cdk.md
+++ b/docs/adr/0002-terraform-over-cdk.md
@@ -3,23 +3,41 @@
 ## Status
 Accepted
 
+## Date
+2026-04-04
+
 ## Context
-We need Infrastructure as Code (IaC) for managing AWS resources. The two main options are:
-- **Terraform (HCL)** — cloud-agnostic, declarative, large community
-- **AWS CDK (Python)** — AWS-specific, imperative, uses familiar Python
+We need Infrastructure as Code for managing AWS resources (S3 buckets, Lambda functions, ECR repos, Step Functions, IAM roles). The project is AWS-only and the author has professional Terraform experience from Intech.
+
+## Options Considered
+
+### 1. Terraform with HCL (chosen)
+Declarative, cloud-agnostic, large community. Module-based composition (`modules/lambda`, `modules/s3-data-lake`, etc.).
+
+### 2. AWS CDK with Python (rejected)
+AWS-specific, imperative, uses the same language as the services. Offers higher-level constructs that abstract boilerplate.
+
+**Rejected because:**
+- The author has professional Terraform experience (Intech's entire infrastructure is Terraform) — CDK would mean learning a new tool for no portfolio benefit
+- Terraform is the most widely used IaC tool; stronger hiring signal for infrastructure-aware roles
+- HCL is readable by non-Python developers — the project targets a general technical audience
+- CDK's higher-level constructs can obscure what's actually being created, making it harder for reviewers to verify IAM policies and resource configs
+
+### 3. AWS SAM / CloudFormation (rejected)
+**Rejected because:** Verbose YAML/JSON, no module system, poor reusability. SAM is Lambda-focused and doesn't cover the full resource set (Step Functions, ECR lifecycle policies, budget alerts).
 
 ## Decision
-Use Terraform with HCL for all infrastructure management.
+Use Terraform with HCL for all infrastructure management. Modules in `infrastructure/modules/`, environments in `infrastructure/environments/{env}/`.
 
 ## Consequences
 **Easier:**
-- More portable — not locked to AWS (though we only use AWS today)
-- Larger community and more learning resources
-- Stronger hiring signal — Terraform is the most widely used IaC tool
-- HCL is widely known and readable by non-Python developers
-- terraform-docs auto-generates module documentation
+- Portable — not locked to AWS (though we only use AWS today)
+- `terraform plan` gives exact diff before apply — critical for a project with budget alerts at $5/month
+- Module composition is straightforward and well-documented
+- `terraform-docs` auto-generates module READMEs
+- State backend (S3 + DynamoDB) is already bootstrapped and proven at Intech
 
 **Harder:**
-- CDK would have given us type safety and the ability to write infrastructure in Python
-- CDK's constructs can abstract more boilerplate than raw Terraform modules
-- Two languages in the project (HCL + Python) instead of one (Python for everything)
+- Two languages in the project (HCL + Python) instead of one
+- CDK's L2/L3 constructs would reduce boilerplate for common patterns (e.g., Lambda + API Gateway)
+- No type safety in HCL — variable mismatches are caught at plan time, not compile time

--- a/docs/adr/0003-direct-api-over-langchain.md
+++ b/docs/adr/0003-direct-api-over-langchain.md
@@ -3,25 +3,47 @@
 ## Status
 Accepted
 
+## Date
+2026-04-04
+
 ## Context
-The enrichment pipeline makes structured LLM calls (player summaries, injury signals, sentiment, fixture outlook). LangChain is the most popular Python framework for LLM orchestration and offers chains, output parsers, and retry logic out of the box. We needed to decide whether to use it or call the Anthropic API directly.
+The enrichment pipeline makes structured LLM calls (player summaries, injury signals, sentiment, fixture outlook). Each call sends a batch of items and expects a JSON array back. We needed to decide whether to use a framework or call the API directly.
+
+## Options Considered
+
+### 1. Direct `anthropic` Python SDK (chosen)
+Call `client.messages.create()` directly. Build our own batching (`FPLEnricher` ABC), validation (Pydantic), and retry logic.
+
+### 2. LangChain (rejected)
+Use LangChain's chains, output parsers, and retry decorators. Provides `ChatAnthropic`, `PydanticOutputParser`, and `RunnableWithRetry` out of the box.
+
+**Rejected because:**
+- Our enrichment calls are simple: system prompt + user message → JSON array. LangChain's chain abstraction adds indirection without simplifying this pattern.
+- LangChain wraps prompts with its own formatting — we need exact control over prompt content for versioning (see ADR-0005) and cost tracking
+- LangChain pulls ~20 transitive dependencies, increasing Lambda container size and cold start time
+- Debugging LangChain's chain-of-responsibility stack is harder than debugging a direct API call
+- Token counting is straightforward from `response.usage` — LangChain's callback system is heavier machinery for the same result
+
+### 3. LiteLLM (rejected)
+Lightweight proxy that normalises different LLM provider APIs behind one interface.
+
+**Rejected because:** We only use Anthropic. Multi-provider abstraction adds a layer with no current benefit. If we added OpenAI later, LiteLLM would be worth revisiting.
 
 ## Decision
-Use the `anthropic` Python SDK directly for all LLM calls. No LangChain anywhere in the pipeline.
+Use the `anthropic` Python SDK directly for all enrichment pipeline LLM calls.
 
 ## Consequences
 **Easier:**
-- Full control over prompt formatting, batching, and retry logic — no fighting framework abstractions
-- Simpler dependency tree — `anthropic` is one package vs LangChain's 20+ transitive dependencies
+- Full control over prompt formatting, batching, and retry logic
+- Simpler dependency tree — `anthropic` is one package
 - Token counting and cost tracking are straightforward from `response.usage`
 - Easier to debug — no hidden prompt wrapping or chain-of-responsibility indirection
-- Structured JSON output validated with Pydantic directly, not LangChain's output parsers
 - Smaller Lambda container images (fewer deps = faster cold starts)
 
 **Harder:**
-- We built our own batching (`FPLEnricher` base class) and retry logic instead of using LangChain's built-in
-- If we add new LLM providers, we'd need to write our own abstraction (LangChain provides this)
-- No built-in support for chains or multi-step reasoning (not needed for our enrichment use case)
+- We built our own batching (`FPLEnricher` base class) and retry logic (~100 lines of code)
+- If we add new LLM providers, we'd need to write our own abstraction
+- No built-in chain composition (not needed for batch enrichment)
 
-## Notes
-The LangGraph agent (`services/agent/`) is a separate concern — it uses LangGraph for the agentic recommendation graph, which is a different pattern from the batch enrichment pipeline.
+## Related
+- The LangGraph agent (`services/agent/`) uses LangGraph for agentic orchestration — a different pattern where the framework earns its place. LangGraph provides state machines, tool calling, and human-in-the-loop, which would be significant to rebuild from scratch. The distinction: batch enrichment is a simple request-response pattern; agentic recommendations need stateful multi-step reasoning.

--- a/docs/adr/0004-tiered-llm-models-and-batching.md
+++ b/docs/adr/0004-tiered-llm-models-and-batching.md
@@ -3,34 +3,61 @@
 ## Status
 Accepted
 
+## Date
+2026-04-04
+
 ## Context
-The enrichment pipeline runs four enrichers per gameweek across ~700 players. LLM API costs scale with token volume, and different tasks have different complexity requirements. We needed to decide which models to use and how to batch items to optimise cost vs quality.
+The enrichment pipeline runs four enrichers per gameweek across ~700 players. LLM API costs scale with token volume, and different tasks have different complexity requirements. We needed a model selection and batching strategy that balances cost, quality, and latency.
+
+## Options Considered
+
+### 1. Single model for everything (rejected)
+Use Sonnet for all enrichers. Simpler code, no model-switching logic.
+
+**Rejected because:** Sonnet at $3/$15 per MTok (in/out) would cost ~$5-8 per gameweek for classification tasks that Haiku handles equally well at $0.25/$1.25 per MTok. Over 38 gameweeks, that's ~$150-300 of unnecessary spend.
+
+### 2. Haiku for everything (rejected)
+Use Haiku for all enrichers including fixture outlook.
+
+**Rejected because:** Fixture outlook requires reasoning about 5-game sequences, team form trends, and schedule difficulty interactions. Testing showed Haiku produced generic recommendations ("moderate difficulty") while Sonnet provided actionable analysis referencing specific fixtures.
+
+### 3. Tiered models with task-appropriate batch sizes (chosen)
+Match model capability to task complexity. Batch simple tasks aggressively, keep complex tasks isolated.
 
 ## Decision
-Use Haiku for simple classification tasks and Sonnet for complex reasoning. Batch multiple items per LLM call where quality allows.
+Use Haiku for classification/summarisation and Sonnet for multi-step reasoning. Batch sizes tuned per enricher.
 
 | Enricher | Model | Batch Size | Reasoning |
 |----------|-------|-----------|-----------|
-| Player Summary | claude-haiku-4-5 | 3 | Form summarisation is templated; moderate context per player |
-| Injury Signal | claude-haiku-4-5 | 5 | Binary classification (injured/not); minimal reasoning needed |
-| Sentiment | claude-haiku-4-5 | 5 | Simple sentiment scoring; bulk-friendly |
-| Fixture Outlook | claude-sonnet-4-6 | 1 | Requires reasoning about fixture runs, team strength, and schedule — needs deeper analysis |
+| Player Summary | claude-haiku-4-5 | 3 | Form summarisation is templated; 3 players per call keeps summaries focused |
+| Injury Signal | claude-haiku-4-5 | 5 | Binary classification (risk score 0-10); minimal per-item context |
+| Sentiment | claude-haiku-4-5 | 5 | Simple sentiment scoring from media mentions; bulk-friendly |
+| Fixture Outlook | claude-sonnet-4-6 | 1 | Requires reasoning about fixture runs and team strength — context isolation needed |
 
 All calls use `max_tokens=4096` and return structured JSON arrays validated with Pydantic.
 
 ## Cost estimate (per gameweek, ~700 players)
-- Haiku calls: ~234 batched calls (3 enrichers) at ~$0.25/MTok in, $1.25/MTok out
-- Sonnet calls: ~700 individual calls at ~$3/MTok in, $15/MTok out
-- Fixture outlook dominates cost — batch size of 1 is the tradeoff for reasoning quality
+
+Based on v1 prompt templates (~200-250 tokens each) and average player data payload (~150 tokens per item):
+
+| Enricher | API Calls | Est. Input Tokens | Est. Output Tokens | Est. Cost |
+|----------|-----------|-------------------|--------------------| ----------|
+| Player Summary (Haiku) | ~234 | ~140K | ~70K | ~$0.12 |
+| Injury Signal (Haiku) | ~140 | ~95K | ~35K | ~$0.07 |
+| Sentiment (Haiku) | ~140 | ~95K | ~35K | ~$0.07 |
+| Fixture Outlook (Sonnet) | ~700 | ~265K | ~140K | ~$2.90 |
+| **Total** | **~1,214** | **~595K** | **~280K** | **~$3.16** |
+
+Fixture outlook dominates cost (~92%). Over a full 38-gameweek season: ~$120. If cost becomes an issue, the first lever is reducing fixture outlook to top-200 players by ownership.
 
 ## Consequences
 **Easier:**
-- Haiku keeps bulk enrichment cheap (~$0.10-0.30 per gameweek for 3 enrichers)
-- Batching amortises per-call overhead and reduces total API calls by 3-5x
+- Haiku keeps bulk enrichment cheap (~$0.26 per gameweek for 3 enrichers)
+- Batching reduces total API calls by 3-5x vs one-per-player
 - Cost report per gameweek enables tracking and alerting on spend drift
 - Langfuse tracing attributes cost to each enricher type
 
 **Harder:**
-- Fixture outlook is expensive relative to others — may need caching or reducing to top-N players
-- Batch size tuning is empirical — too large degrades output quality, too small wastes API calls
-- Model version pinning means manual updates when new model versions release
+- Two models means two pricing tiers to track and two potential points of failure
+- Batch size tuning is empirical — too large degrades output quality, too small wastes calls
+- Model version pinning (`claude-haiku-4-5-20251001`) means manual updates when new versions release

--- a/docs/adr/0005-prompt-versioning-by-directory.md
+++ b/docs/adr/0005-prompt-versioning-by-directory.md
@@ -3,11 +3,29 @@
 ## Status
 Accepted
 
+## Date
+2026-04-04
+
 ## Context
 LLM prompts are a critical part of the enrichment pipeline. Prompt changes can silently alter output quality, break downstream validation, or shift cost profiles. We needed a strategy for versioning prompts that supports iteration without risking production stability.
 
+## Options Considered
+
+### 1. Inline prompts in Python code (rejected)
+Embed prompt strings directly in enricher classes.
+
+**Rejected because:** Prompt changes become code changes, requiring full CI/test cycles. Makes it hard to compare versions side by side. Mixes concerns — the enricher logic shouldn't change when you're only tweaking wording.
+
+### 2. Database-stored prompts (rejected)
+Store prompts in DynamoDB or S3 with version metadata, loaded at runtime.
+
+**Rejected because:** Adds infrastructure dependency for something that changes infrequently. Harder to review in PRs. Version history lives in a database rather than git, losing diff/blame capabilities.
+
+### 3. Git-tracked directory-based versioning (chosen)
+Plain text files in `prompts/v{N}/` directories, loaded by `load_prompt(enricher_name, version)`.
+
 ## Decision
-Store prompt templates as plain text files in versioned directories: `services/enrich/src/fpl_enrich/prompts/v{N}/`. Each enricher loads its prompt at runtime via `load_prompt(enricher_name, version)`.
+Store prompt templates as plain text files in versioned directories: `services/enrich/src/fpl_enrich/prompts/v{N}/`.
 
 ```
 prompts/
@@ -26,15 +44,25 @@ prompts/
 - Prompts are plain text with `{batch_size}` and `{batch_items}` placeholders — no Jinja or complex templating
 - Each prompt specifies its expected JSON output schema inline
 
+## Deployment coordination
+The `prompt_version` default is hardcoded in the Lambda handler (`"v1"`). To roll out a new version:
+1. Merge the new `v2/` directory
+2. Update the Step Functions state machine input to pass `prompt_version: "v2"`
+3. Or update the handler default — this is a code change and goes through CI
+
+**Risk:** If someone deploys new prompt files but forgets to update the version parameter, the old version continues running. This is acceptable because:
+- Prompts are additive (v1 still works after v2 is deployed)
+- Langfuse traces include `prompt_version` metadata, so version drift is visible in the dashboard
+- The Step Functions input is the single source of truth for "what version is running"
+
 ## Consequences
 **Easier:**
 - A/B testing: run v1 and v2 side by side by passing different `prompt_version` values
-- Rollback: revert to previous version without code changes
-- Auditability: git history shows exactly what changed between versions
+- Rollback: revert to previous version by changing one parameter, no code deploy needed
+- Auditability: git history shows exactly what changed between versions, with PR review
 - Langfuse traces include `prompt_version` metadata for quality comparison
-- No code changes needed to iterate on prompts — just add a new directory
 
 **Harder:**
 - No compile-time validation that prompt placeholders match code expectations
-- Directory proliferation over time (mitigated: old versions can be archived)
-- Prompt and code must stay in sync — a new output field requires both a prompt change and a validator update
+- Deployment coordination requires updating the version parameter (see above)
+- Prompt and code must stay in sync — a new output field requires both a prompt change and a validator update in the same PR

--- a/docs/adr/0006-s3-prefix-idempotency.md
+++ b/docs/adr/0006-s3-prefix-idempotency.md
@@ -3,33 +3,50 @@
 ## Status
 Accepted
 
+## Date
+2026-04-04
+
 ## Context
 Data collectors and transformers are invoked by Step Functions, which retries on failure. Without idempotency, retries produce duplicate files in S3. We needed a mechanism to detect "already done" and skip re-processing.
 
-Options considered:
-1. **DynamoDB state table** — write a record on completion, check before starting
-2. **S3 prefix existence check** — list objects under the output prefix, skip if non-empty
-3. **Lambda destination deduplication** — use request IDs to prevent re-execution
+## Options Considered
+
+### 1. DynamoDB state table (rejected)
+Write a completion record on success, check before starting. Schema: `{season, gameweek, stage, status, timestamp}`.
+
+**Rejected because:** Adds a DynamoDB table to manage, introduces eventual consistency between S3 and the state table, and requires cleanup/TTL logic. The state table would duplicate information already implicit in S3 (if the file exists, the work is done).
+
+### 2. Lambda destination deduplication (rejected)
+Use Lambda request IDs or idempotency tokens to prevent re-execution.
+
+**Rejected because:** Only prevents exact duplicate invocations, not logical duplicates (same gameweek, different invocation). Doesn't help with "was this gameweek already collected?" checks.
+
+### 3. S3 prefix existence check (chosen)
+Call `s3_client.list_objects(bucket, prefix)` before each operation — if files exist under the output prefix, skip.
 
 ## Decision
-Use S3 prefix existence checks. Before each collect/transform operation, call `s3_client.list_objects(bucket, prefix)` — if files exist, return early with `records_collected=0`.
+Use S3 prefix existence checks for idempotency. Before each collect/transform operation, check if output already exists. A `force=True` parameter overrides the check for backfills.
 
 ```python
 if not force and self._output_exists(prefix):
     return CollectionResponse(status="success", records_collected=0, output_path=prefix)
 ```
 
-A `force=True` parameter overrides the check for backfills.
+## Partial write mitigation
+Each collector writes a **single JSON file per invocation** (e.g., one `bootstrap/{timestamp}.json`). S3 `PutObject` is atomic — the object either fully exists or doesn't. There is no scenario where a collector writes 3 of 4 files because each method produces exactly one output file.
+
+If the Lambda crashes *before* the `PutObject` call, no file is written and the next retry correctly sees an empty prefix. If it crashes *after*, the file exists and the retry correctly skips.
+
+The `force=True` parameter exists for backfills and manual re-processing, not as a mitigation for partial writes.
 
 ## Consequences
 **Easier:**
-- No additional infrastructure — S3 is already the data store
-- S3 is the single source of truth: if the file is there, the work is done
+- No additional infrastructure — S3 is already the data store and source of truth
 - Hive-style partitioning (`season={s}/gameweek={gw}/`) makes prefix checks natural
-- Simple to reason about: "data exists = done"
-- `force=True` provides an escape hatch for re-processing
+- Simple to reason about: "data exists at prefix = work is done"
+- `list_objects` is cheap (~$0.005 per 1,000 requests) and fast (~50-100ms)
 
 **Harder:**
-- Partial writes: if a collector writes 3 of 4 files and fails, the prefix check sees it as "done" — the `force` flag handles this but requires manual intervention
-- `list_objects` adds latency (~50-100ms) per check — acceptable for our Lambda execution model
-- Not suitable for high-concurrency scenarios (no locking) — fine for our scheduled, sequential pipeline
+- If the output format changes (e.g., collector starts writing multiple files), the single-file atomicity assumption breaks — would need to revisit
+- `list_objects` adds latency per check — acceptable for batch Lambda, not suitable for real-time
+- No locking — two concurrent invocations could both see "empty" and both write. Acceptable because our Step Functions pipeline is sequential, not parallel

--- a/docs/adr/0007-container-images-for-lambda.md
+++ b/docs/adr/0007-container-images-for-lambda.md
@@ -3,33 +3,45 @@
 ## Status
 Accepted
 
+## Date
+2026-04-04
+
 ## Context
-AWS Lambda supports two deployment models: zip packages (up to 250 MB uncompressed) and container images (up to 10 GB). Our services depend on PyArrow, pandas, numpy, and the Anthropic SDK — heavy packages that push against zip size limits.
+AWS Lambda supports two deployment models: zip packages (up to 250 MB uncompressed) and container images (up to 10 GB). Our services depend on PyArrow (~180 MB), pandas (~60 MB), numpy (~30 MB), and the Anthropic SDK — these alone exceed the zip size limit.
+
+## Options Considered
+
+### 1. Zip packages with Lambda layers (rejected)
+Split dependencies into layers (e.g., a "data science" layer with pandas/pyarrow, a "core" layer with boto3/pydantic). Application code as a thin zip.
+
+**Rejected because:**
+- Layer management adds operational overhead — layers must be versioned, published, and compatible across services
+- Total uncompressed size (layers + code) still has a 250 MB limit, which our deps exceed
+- Layers are region-specific and must be rebuilt per architecture (x86 vs ARM)
+
+### 2. Container images via ECR (chosen)
+Multi-stage Dockerfile per service. Builder stage installs dependencies, runtime stage copies only what's needed into the AWS Lambda Python base image.
+
+### 3. Zip packages with stripped/compiled deps (rejected)
+Strip debug symbols, compile `.py` to `.pyc`, remove tests from packages to fit under 250 MB.
+
+**Rejected because:** Fragile — each dependency update risks breaking the size budget. PyArrow alone is ~180 MB and can't be meaningfully stripped.
 
 ## Decision
-Deploy all Lambda functions as container images via ECR. Each service has a multi-stage Dockerfile:
-1. **Builder stage** — installs dependencies with pip
-2. **Runtime stage** — copies installed packages into the AWS Lambda Python base image
-
-```dockerfile
-FROM public.ecr.aws/lambda/python:3.11 AS builder
-# ... install deps ...
-
-FROM public.ecr.aws/lambda/python:3.11
-COPY --from=builder /var/lang/lib/python3.11/site-packages /var/lang/lib/python3.11/site-packages
-```
+Deploy all Lambda functions as container images via ECR. Each service has a multi-stage Dockerfile.
 
 One ECR repository per service (`fpl-data-dev`, `fpl-enrich-dev`, `fpl-agent-dev`), with immutable tags and a lifecycle policy retaining the last 10 images.
 
 ## Consequences
 **Easier:**
-- No size constraints — PyArrow + pandas + numpy alone exceed 250 MB
+- No size constraints — 10 GB limit is effectively unlimited for Python services
 - Identical local and deployed environments (same Docker image)
-- Multi-stage builds keep final image lean
+- Multi-stage builds keep final image lean (~300 MB vs installing everything from scratch)
 - `docker build && docker push` is simpler than managing Lambda layers
-- Immutable tags ensure deployed code is reproducible
+- CI pipeline is straightforward: build, tag with commit SHA, push to ECR, update Lambda
 
 **Harder:**
-- Cold start is slower (~2-5s) compared to zip (~1-2s) — acceptable for our batch pipeline (not user-facing)
-- ECR storage cost (minimal — lifecycle policy keeps only 10 images)
+- Cold start is slower (~2-5s) compared to zip (~1-2s) — acceptable for a batch pipeline that runs weekly, not user-facing
+- ECR storage cost (minimal — lifecycle policy keeps only 10 images per repo)
 - Local testing requires Docker (vs zip which can run with just `python`)
+- Image builds are slower than zip packaging (~30-60s vs ~5s in CI)

--- a/docs/adr/0008-s3-data-lake-layer-design.md
+++ b/docs/adr/0008-s3-data-lake-layer-design.md
@@ -1,0 +1,80 @@
+# ADR-0008: S3 Data Lake Layer Design
+
+## Status
+Accepted
+
+## Date
+2026-04-04
+
+## Context
+The pipeline collects data from multiple sources (FPL API, Understat, news), validates it, transforms it, enriches it with LLMs, and serves it to a dashboard. We needed a storage layout that supports this multi-stage processing while keeping data discoverable and preventing raw/processed data from mixing.
+
+## Options Considered
+
+### 1. Flat structure with naming conventions (rejected)
+All data in one S3 prefix, distinguished by file naming: `fpl_bootstrap_raw_2025-26_gw01.json`, `fpl_bootstrap_clean_2025-26_gw01.parquet`.
+
+**Rejected because:** No structural enforcement of data quality stages. Easy to accidentally read raw data where clean is expected. IAM can't scope permissions by processing stage.
+
+### 2. Separate S3 buckets per layer (rejected)
+`fpl-raw-dev`, `fpl-clean-dev`, `fpl-enriched-dev`, `fpl-curated-dev` — one bucket per quality tier.
+
+**Rejected because:** Multiplies infrastructure (4 buckets, 4 lifecycle configs, 4 IAM statements). Cross-bucket operations (e.g., reading raw and writing clean) require broader S3 permissions. AWS account limits on buckets are generous but this doesn't scale well to multiple datasets.
+
+### 3. Single bucket with prefix-based layers and Hive partitioning (chosen)
+One `fpl-data-lake-dev` bucket with top-level prefixes defining data quality stages and Hive-style partition keys for discovery.
+
+## Decision
+Single S3 bucket with four data layers plus a dead-letter queue, using Hive-style partitioning:
+
+```
+s3://fpl-data-lake-dev/
+  raw/              <- API responses as-is (JSON)
+    fpl-api/season=2025-26/bootstrap/{timestamp}.json
+    understat/season=2025-26/players/{id}/{timestamp}.json
+    news/date=2026-04-01/rss_articles.jsonl
+  clean/            <- Validated, typed, deduplicated (Parquet)
+    players/season=2025-26/gameweek=01/players.parquet
+  enriched/         <- LLM-augmented data (Parquet)
+    player_summaries/season=2025-26/gameweek=01/summaries.parquet
+  curated/          <- Dashboard-ready aggregations (Parquet)
+    dashboard/season=2025-26/latest.parquet
+  dlq/              <- Failed records for investigation
+    season=2025-26/gameweek=01/validation_failures.jsonl
+```
+
+### Format choices
+- **Raw**: JSON — preserve original API response exactly as received
+- **Clean/Enriched/Curated**: Parquet with zstd compression — columnar, compact, schema-enforced, fast for analytics
+- **DLQ**: JSONL — human-readable for debugging, one record per line
+
+### Partitioning
+Hive-style keys (`season=`, `gameweek=`, `date=`) enable:
+- Partition pruning in queries (Athena, DuckDB)
+- Natural S3 prefix-based idempotency checks (see ADR-0006)
+- Lifecycle rules scoped by prefix (raw/ expires at 90 days, dlq/ at 30 days)
+
+## Why four layers (not three or five)
+- **Raw** exists to preserve source data for reprocessing without re-fetching APIs
+- **Clean** exists because validation and type-casting must happen before enrichment — LLM inputs must be predictable
+- **Enriched** is separate from clean because LLM enrichment is expensive and may fail — clean data should be usable independently
+- **Curated** exists for dashboard-specific aggregations that join across sources — downstream consumers shouldn't repeat this joining logic
+- A fifth "staging" layer was considered and rejected — clean serves this purpose
+
+## Why Parquet with zstd (not Delta Lake, Iceberg, or CSV)
+- **Delta Lake / Iceberg**: Excellent for ACID transactions and time-travel, but require a metastore (Glue Catalog) and add complexity. Our pipeline is append-only per gameweek with no concurrent writers — ACID is overkill.
+- **CSV**: No schema enforcement, no compression, slow to read. Only advantage is human readability, which JSONL in the DLQ handles for debugging.
+- **Parquet + zstd**: Industry standard for columnar analytics. zstd gives better compression ratios than snappy at comparable speed. PyArrow reads/writes Parquet natively, and Athena/DuckDB query it directly.
+
+## Consequences
+**Easier:**
+- One bucket to manage, one set of lifecycle rules, one IAM policy
+- Hive partitioning is universally supported (Athena, Spark, DuckDB, pandas)
+- Each layer has a clear contract: raw=JSON, clean/enriched/curated=Parquet
+- Lifecycle rules naturally scope by prefix (raw/ transitions to IA, dlq/ expires)
+- Easy to add new data sources — just create a new prefix under raw/
+
+**Harder:**
+- No ACID transactions — if the transform Lambda fails mid-write, a partial Parquet could exist (mitigated by atomic S3 PUT — see ADR-0006)
+- No schema registry — schema evolution must be managed manually via `schema_version` in Parquet metadata
+- Single bucket means a compromised Lambda could read/write any layer (mitigated: IAM scoping by prefix is possible but not implemented yet)

--- a/docs/adr/0009-langfuse-for-llm-observability.md
+++ b/docs/adr/0009-langfuse-for-llm-observability.md
@@ -1,0 +1,67 @@
+# ADR-0009: Langfuse for LLM Observability
+
+## Status
+Accepted
+
+## Date
+2026-04-04
+
+## Context
+The enrichment pipeline makes ~1,200 LLM API calls per gameweek across four enrichers. We need observability to track cost, latency, output quality, and prompt version performance. Without it, degraded output quality or cost spikes would go unnoticed until they hit the dashboard or the AWS bill.
+
+## Options Considered
+
+### 1. Custom logging to CloudWatch (rejected)
+Log token counts, latency, and cost to CloudWatch Metrics. Build dashboards in CloudWatch.
+
+**Rejected because:** CloudWatch is good for infrastructure metrics but poor for LLM-specific workflows. No built-in support for prompt versioning, trace trees, or output quality scoring. Building a custom LLM dashboard in CloudWatch would duplicate what observability tools provide out of the box.
+
+### 2. LangSmith (rejected)
+LangChain's native observability platform. Tight integration with LangChain, traces, datasets, evaluation.
+
+**Rejected because:** Tightly coupled to LangChain — we don't use LangChain (see ADR-0003). While LangSmith can work without LangChain, its SDK and documentation assume LangChain patterns. Also, LangSmith's pricing is opaque for self-hosted/free tier usage.
+
+### 3. Helicone (rejected)
+Proxy-based LLM observability — sits between your app and the LLM API, captures all traffic.
+
+**Rejected because:** Proxy architecture adds latency to every LLM call and introduces a single point of failure. Our batch pipeline can tolerate some observability delay — we don't need real-time interception.
+
+### 4. Langfuse (chosen)
+Open-source LLM observability with a Python decorator-based SDK. Supports traces, spans, scoring, prompt management, and cost tracking.
+
+## Decision
+Use Langfuse for all LLM observability. Integration via the `@observe` decorator on enricher methods and the Lambda handler.
+
+```python
+@observe(name="enricher_batch_call")
+def _call_llm(self, batch: list[dict]) -> list[dict]:
+    langfuse_context.update_current_observation(
+        metadata={"enricher": self.__class__.__name__, "prompt_version": self.prompt_version}
+    )
+    # ... LLM call ...
+    langfuse_context.score_current_observation(
+        name="output_count_valid",
+        value=1.0 if len(results) == len(batch) else 0.0,
+    )
+```
+
+Keys stored in Secrets Manager (`/fpl-platform/dev/langfuse-public-key`, `/fpl-platform/dev/langfuse-secret-key`).
+
+## What we trace
+- **Per batch call:** enricher name, batch size, prompt version, input/output token counts, latency, model
+- **Per gameweek run:** session ID (`{season}-gw{gameweek}`), total calls, total cost, success/failure counts
+- **Quality scores:** output count validation (did the LLM return the right number of items?)
+
+## Consequences
+**Easier:**
+- `@observe` decorator is minimally invasive — one line per method, no restructuring needed
+- Prompt version metadata enables A/B comparison between v1 and v2 prompts in the Langfuse dashboard
+- Cost attribution per enricher type — instantly see that fixture outlook is 92% of spend (see ADR-0004)
+- Open-source with generous free tier — no vendor lock-in, can self-host if needed
+- Session-based grouping (`season-gw{N}`) makes it easy to investigate a specific gameweek's run
+
+**Harder:**
+- Adds `langfuse` as a dependency with its own transitive deps (OpenTelemetry, protobuf, etc.)
+- Two more secrets to manage in Secrets Manager
+- If Langfuse's cloud service is down, tracing silently fails (by design — doesn't block the pipeline), but you lose observability for that run
+- Decorator-based approach means tracing is tied to the code structure — moving logic between methods requires moving decorators


### PR DESCRIPTION
## Summary
- **Improved ADR-0001 through ADR-0007**: Added dates, "Options Considered" sections with rejected alternatives and rationale, project-specific context
- **ADR-0008**: S3 data lake layer design — why four layers, Hive partitioning, Parquet+zstd over Delta Lake/CSV
- **ADR-0009**: Langfuse for LLM observability — chosen over LangSmith, Helicone, and custom CloudWatch

Key improvements per the review feedback:
- ADR-0001/0002: Added portfolio project context and Intech experience rationale
- ADR-0004: Grounded cost estimates in actual v1 prompt template token counts (~200-250 tokens)
- ADR-0005: Addressed deployment coordination risk (who sets prompt_version?)
- ADR-0006: Clarified partial write is a non-issue due to single-file-per-invocation + atomic S3 PUT
- ADR-0007: Added Lambda layers and stripped deps as rejected alternatives

## Testing
N/A — documentation only