### PR TITLE
fix(ci): auto-discover Lambdas by ECR repo for deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,13 +71,10 @@ jobs:
         include:
           - name: data
             changed: ${{ needs.detect-changes.outputs.data }}
-            lambda_function: fpl-api-collector-dev
           - name: enrich
             changed: ${{ needs.detect-changes.outputs.enrich }}
-            lambda_function: fpl-enricher-dev
           - name: agent
             changed: ${{ needs.detect-changes.outputs.agent }}
-            lambda_function: fpl-agent-dev
     steps:
       - uses: actions/checkout@v4
         if: matrix.changed == 'true'
@@ -108,13 +105,30 @@ jobs:
           docker push $ECR_REGISTRY/fpl-${{ matrix.name }}-dev:$IMAGE_TAG
           docker push $ECR_REGISTRY/fpl-${{ matrix.name }}-dev:latest
 
-      - name: Update Lambda function
+      - name: Update all Lambdas using this ECR image
         if: matrix.changed == 'true'
         env:
           ECR_REGISTRY: ${{ steps.ecr-login.outputs.registry }}
           IMAGE_TAG: ${{ github.sha }}
+          ECR_REPO: fpl-${{ matrix.name }}-dev
         run: |
-          aws lambda update-function-code \
-            --function-name ${{ matrix.lambda_function }} \
-            --image-uri $ECR_REGISTRY/fpl-${{ matrix.name }}-dev:$IMAGE_TAG \
-            --region eu-west-2
+          IMAGE_URI="$ECR_REGISTRY/$ECR_REPO:$IMAGE_TAG"
+          echo "Updating Lambdas using $ECR_REPO to $IMAGE_URI"
+
+          # Find all Lambda functions whose current image comes from this ECR repo
+          FUNCTIONS=$(aws lambda list-functions --region eu-west-2 \
+            --query "Functions[?starts_with(PackageType, 'Image')].FunctionName" \
+            --output text)
+
+          for FUNC in $FUNCTIONS; do
+            CURRENT_IMAGE=$(aws lambda get-function --function-name "$FUNC" --region eu-west-2 \
+              --query "Code.ImageUri" --output text 2>/dev/null || true)
+
+            if echo "$CURRENT_IMAGE" | grep -q "$ECR_REPO"; then
+              echo "Updating $FUNC..."
+              aws lambda update-function-code \
+                --function-name "$FUNC" \
+                --image-uri "$IMAGE_URI" \
+                --region eu-west-2
+            fi
+          done


### PR DESCRIPTION
## What
Replace hardcoded `lambda_function` names in the deploy workflow matrix with dynamic discovery based on ECR repo name.

## Why
The previous deploy failed because `fpl-api-collector-dev` doesn't exist — Terraform names it `fpl-dev-fpl-api-collector`. Hardcoding names also breaks every time a new Lambda is added. 

## How
After pushing a Docker image to ECR, the workflow:
1. Lists all container-image Lambda functions in the account
2. Checks each function's current image URI for the ECR repo name (e.g. `fpl-data-dev`)
3. Updates matching functions to the new image

Adding new Lambdas in Terraform automatically picks them up on the next deploy — no workflow changes needed.

## Testing
- Workflow syntax valid (no matrix `lambda_function` references remain)
- Logic: `aws lambda list-functions` → filter by `PackageType=Image` → match on ECR repo name → update