### PR TITLE
refactor(data): backfill via Step Functions instead of direct Lambda calls

### DIFF
--- a/services/data/src/fpl_data/scripts/backfill.py
+++ b/services/data/src/fpl_data/scripts/backfill.py
@@ -1,127 +1,98 @@
-"""Backfill FPL pipeline for a range of gameweeks.
+"""Backfill FPL pipeline for a range of gameweeks via Step Functions.
+
+Triggers a Step Functions execution for each gameweek, waits for completion,
+and reports results. Uses the same pipeline as the weekly scheduled run.
 
 Usage:
     python -m fpl_data.scripts.backfill --season 2025-26 --start-gw 1 --end-gw 20
     python -m fpl_data.scripts.backfill --season 2025-26 --start-gw 5 --end-gw 5
-    python -m fpl_data.scripts.backfill --season 2025-26 --start-gw 1 --end-gw 5 --include-enrichment
 """
 
 import argparse
-import asyncio
+import json
 import logging
 import sys
 import time
-from datetime import UTC
 
-from fpl_data.handlers.fpl_api_handler import main as collect_fpl
-from fpl_data.handlers.transform import main as transform
-from fpl_data.handlers.validator import main as validate
+import boto3
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
 logger = logging.getLogger(__name__)
 
-
-async def _collect_understat(season: str, gameweek: int) -> dict[str, str]:
-    """Collect Understat data. Imported lazily to avoid hard dependency."""
-    try:
-        from fpl_data.collectors.understat_collector import UnderstatCollector
-        from fpl_lib.clients.s3 import S3Client
-
-        collector = UnderstatCollector(s3_client=S3Client(), output_bucket="fpl-data-lake-dev")
-        result = await collector.collect_league_stats(season=season)
-        return {"understat": result.status}
-    except Exception as e:
-        logger.warning("Understat collection failed for GW%d: %s", gameweek, e)
-        return {"understat": f"failed: {e}"}
+DEFAULT_STATE_MACHINE = "fpl-dev-collection-pipeline"
+DEFAULT_REGION = "eu-west-2"
+POLL_INTERVAL_SECONDS = 10
 
 
-async def _collect_news(gameweek: int) -> dict[str, str]:
-    """Collect news data. Imported lazily to avoid hard dependency."""
-    try:
-        from datetime import datetime
-
-        from fpl_data.collectors.news_collector import NewsCollector
-        from fpl_lib.clients.s3 import S3Client
-
-        collector = NewsCollector(s3_client=S3Client(), output_bucket="fpl-data-lake-dev")
-        date = datetime.now(UTC).strftime("%Y-%m-%d")
-        result = await collector.collect_rss_feeds(date=date)
-        return {"news": result.status}
-    except Exception as e:
-        logger.warning("News collection failed for GW%d: %s", gameweek, e)
-        return {"news": f"failed: {e}"}
+def _get_state_machine_arn(name: str, region: str) -> str:
+    """Resolve state machine name to ARN."""
+    client = boto3.client("stepfunctions", region_name=region)
+    paginator = client.get_paginator("list_state_machines")
+    for page in paginator.paginate():
+        for sm in page["stateMachines"]:
+            if sm["name"] == name:
+                return sm["stateMachineArn"]
+    raise ValueError(f"State machine '{name}' not found in {region}")
 
 
-async def _run_enrichment(season: str, gameweek: int) -> dict[str, str]:
-    """Run LLM enrichment. Imported lazily — expensive, opt-in only."""
-    try:
-        from fpl_enrich.handlers.enricher import main as enrich
-
-        result = await enrich(season=season, gameweek=gameweek)
-        return {"enrich": result.get("status", "unknown")}
-    except Exception as e:
-        logger.warning("Enrichment failed for GW%d: %s", gameweek, e)
-        return {"enrich": f"failed: {e}"}
-
-
-async def backfill_gameweek(
+def _start_execution(
+    sfn_client: boto3.client,
+    state_machine_arn: str,
     season: str,
     gameweek: int,
-    include_enrichment: bool = False,
-) -> dict[str, str]:
-    """Run the full pipeline for a single gameweek with force=True."""
-    results: dict[str, str] = {}
+) -> str:
+    """Start a Step Functions execution and return the execution ARN."""
+    response = sfn_client.start_execution(
+        stateMachineArn=state_machine_arn,
+        name=f"backfill-{season}-gw{gameweek:02d}-{int(time.time())}",
+        input=json.dumps(
+            {
+                "season": season,
+                "gameweek": gameweek,
+                "force": True,
+            }
+        ),
+    )
+    return response["executionArn"]
 
-    # Step 1: Collect FPL API
-    try:
-        result = await collect_fpl(season=season, gameweek=gameweek, force=True)
-        results["collect_fpl"] = result.get("status", "unknown")
-    except Exception as e:
-        logger.error("FPL collection failed for GW%d: %s", gameweek, e)
-        results["collect_fpl"] = f"failed: {e}"
-        return results
 
-    # Step 2: Collect Understat (non-blocking — continue on failure)
-    results.update(await _collect_understat(season, gameweek))
+def _wait_for_execution(sfn_client: boto3.client, execution_arn: str) -> dict[str, str]:
+    """Poll until the execution completes. Returns status and details."""
+    while True:
+        response = sfn_client.describe_execution(executionArn=execution_arn)
+        status = response["status"]
 
-    # Step 3: Collect News (non-blocking — continue on failure)
-    results.update(await _collect_news(gameweek))
+        if status == "RUNNING":
+            logger.info("  ... still running")
+            time.sleep(POLL_INTERVAL_SECONDS)
+            continue
 
-    # Step 4: Validate
-    try:
-        result = await validate(season=season, gameweek=gameweek)
-        results["validate"] = result.get("status", "unknown")
-    except Exception as e:
-        logger.error("Validation failed for GW%d: %s", gameweek, e)
-        results["validate"] = f"failed: {e}"
-        return results
-
-    # Step 5: Transform
-    try:
-        result = await transform(season=season, gameweek=gameweek, force=True)
-        results["transform"] = result.get("status", "unknown")
-    except Exception as e:
-        logger.error("Transform failed for GW%d: %s", gameweek, e)
-        results["transform"] = f"failed: {e}"
-        return results
-
-    # Step 6: Enrich (opt-in — expensive)
-    if include_enrichment:
-        results.update(await _run_enrichment(season, gameweek))
-
-    return results
+        result: dict[str, str] = {"status": status}
+        if status == "SUCCEEDED":
+            result["output"] = response.get("output", "")
+        elif status == "FAILED":
+            result["error"] = response.get("error", "unknown")
+            result["cause"] = response.get("cause", "")
+        return result
 
 
 def main() -> None:
-    """Parse args and run backfill across gameweek range."""
-    parser = argparse.ArgumentParser(description="Backfill FPL pipeline for a range of gameweeks")
+    """Parse args and run backfill via Step Functions."""
+    parser = argparse.ArgumentParser(
+        description="Backfill FPL pipeline via Step Functions for a range of gameweeks"
+    )
     parser.add_argument("--season", required=True, help="Season string, e.g. 2025-26")
     parser.add_argument("--start-gw", type=int, required=True, help="First gameweek to backfill")
     parser.add_argument("--end-gw", type=int, required=True, help="Last gameweek to backfill")
     parser.add_argument(
-        "--include-enrichment",
-        action="store_true",
-        help="Include LLM enrichment step (expensive, skipped by default)",
+        "--state-machine",
+        default=DEFAULT_STATE_MACHINE,
+        help=f"Step Functions state machine name (default: {DEFAULT_STATE_MACHINE})",
+    )
+    parser.add_argument(
+        "--region",
+        default=DEFAULT_REGION,
+        help=f"AWS region (default: {DEFAULT_REGION})",
     )
     args = parser.parse_args()
 
@@ -129,36 +100,46 @@ def main() -> None:
         logger.error("Invalid gameweek range: %d-%d", args.start_gw, args.end_gw)
         sys.exit(1)
 
+    # Resolve state machine ARN
+    state_machine_arn = _get_state_machine_arn(args.state_machine, args.region)
+    logger.info("Using state machine: %s", state_machine_arn)
+
+    sfn_client = boto3.client("stepfunctions", region_name=args.region)
+
     logger.info(
-        "Backfilling %s from GW%d to GW%d (enrichment=%s)",
+        "Backfilling %s from GW%d to GW%d",
         args.season,
         args.start_gw,
         args.end_gw,
-        args.include_enrichment,
     )
 
     all_results: dict[int, dict[str, str]] = {}
 
     for gw in range(args.start_gw, args.end_gw + 1):
         logger.info("--- Gameweek %d ---", gw)
-        results = asyncio.run(backfill_gameweek(args.season, gw, args.include_enrichment))
-        all_results[gw] = results
+
+        execution_arn = _start_execution(sfn_client, state_machine_arn, args.season, gw)
+        logger.info("  Started execution: %s", execution_arn.split(":")[-1])
+
+        result = _wait_for_execution(sfn_client, execution_arn)
+        all_results[gw] = result
+
+        if result["status"] == "SUCCEEDED":
+            logger.info("  GW%d succeeded", gw)
+        else:
+            logger.error("  GW%d failed: %s", gw, result.get("cause", result.get("error", "")))
 
         if gw < args.end_gw:
-            logger.info("Sleeping 2s before next gameweek...")
+            logger.info("  Sleeping 2s before next gameweek...")
             time.sleep(2)
 
     # Summary
     logger.info("=== Backfill Summary ===")
-    succeeded = 0
-    failed = 0
-    for gw, results in all_results.items():
-        status = "OK" if all("failed" not in v for v in results.values()) else "FAILED"
-        if status == "OK":
-            succeeded += 1
-        else:
-            failed += 1
-        logger.info("  GW%02d: %s — %s", gw, status, results)
+    succeeded = sum(1 for r in all_results.values() if r["status"] == "SUCCEEDED")
+    failed = sum(1 for r in all_results.values() if r["status"] != "SUCCEEDED")
+
+    for gw, result in all_results.items():
+        logger.info("  GW%02d: %s", gw, result["status"])
 
     logger.info("Total: %d succeeded, %d failed", succeeded, failed)
     if failed > 0:


### PR DESCRIPTION
## What
Rewrite the backfill script to trigger Step Functions executions instead of calling Lambda handlers directly.

## Why
The previous version imported Lambda handler functions and called them in Python, bypassing Step Functions entirely. This meant backfills had no retry logic, no validation gating, and no error routing to PipelineFailed. Now backfills get the exact same pipeline as scheduled runs.

## How
For each gameweek, the script:
1. Starts a Step Functions execution with `{season, gameweek, force: true}`
2. Polls `describe_execution` every 10s until completion
3. Reports SUCCEEDED/FAILED per gameweek with a summary at the end

```bash
python -m fpl_data.scripts.backfill --season 2025-26 --start-gw 1 --end-gw 20
```

Optional flags: `--state-machine` (default: `fpl-dev-collection-pipeline`), `--region` (default: `eu-west-2`)

## Testing
- `ruff check` + `ruff format --check` clean
- No direct Lambda imports remain

Closes #35