### PR TITLE
fix(infra): support backfill and auto-resolve input modes in Step Functions

### DIFF
--- a/infrastructure/environments/dev/main.tf
+++ b/infrastructure/environments/dev/main.tf
@@ -327,12 +327,11 @@ resource "aws_cloudwatch_event_target" "pipeline_target" {
   arn      = module.pipeline.state_machine_arn
   role_arn = aws_iam_role.eventbridge_sfn.arn
 
-  # ResolveGameweek (first pipeline step) auto-detects the latest finished
-  # gameweek from the FPL API. last_processed_gw=0 means "process whatever
-  # is latest". The pipeline exits cleanly via PipelineSkipped if there's
-  # nothing new to process.
+  # gameweek=0 triggers auto-resolution via the FPL API (ResolveGameweek).
+  # gameweek>0 skips resolution and runs that specific gameweek (backfill mode).
   input = jsonencode({
     season            = "2025-26"
+    gameweek          = 0
     last_processed_gw = 0
     force             = false
   })

--- a/infrastructure/step_function_definitions/fpl-collection-pipeline.json.tpl
+++ b/infrastructure/step_function_definitions/fpl-collection-pipeline.json.tpl
@@ -1,7 +1,19 @@
 {
   "Comment": "FPL data collection, validation, transformation, and enrichment pipeline",
-  "StartAt": "ResolveGameweek",
+  "StartAt": "CheckInputMode",
   "States": {
+    "CheckInputMode": {
+      "Type": "Choice",
+      "Comment": "If gameweek is provided (backfill), skip resolution. Otherwise resolve from FPL API.",
+      "Choices": [
+        {
+          "Variable": "$.gameweek",
+          "NumericGreaterThan": 0,
+          "Next": "CollectFPLData"
+        }
+      ],
+      "Default": "ResolveGameweek"
+    },
     "ResolveGameweek": {
       "Type": "Task",
       "Resource": "${lambda_arn_resolve_gameweek}",
@@ -37,9 +49,9 @@
           "Next": "PipelineSkipped"
         }
       ],
-      "Default": "PrepareInput"
+      "Default": "PrepareResolvedInput"
     },
-    "PrepareInput": {
+    "PrepareResolvedInput": {
       "Type": "Pass",
       "Comment": "Flatten resolved gameweek into top-level state for downstream steps",
       "Parameters": {


### PR DESCRIPTION
## What
Add `CheckInputMode` as the first state in the Step Functions pipeline to support two input modes:

- **Backfill**: `{"season": "2025-26", "gameweek": 32, "force": true}` — skips ResolveGameweek, runs that specific GW
- **Scheduled**: `{"season": "2025-26", "gameweek": 0, "last_processed_gw": 0}` — resolves latest finished GW from FPL API

## Why
The backfill script sends `{gameweek: N}` but the state machine expected `{last_processed_gw: N}` for the ResolveGameweek step, causing:
```
The JSONPath '$.last_processed_gw' could not be found in the input
```

## How
```
CheckInputMode (Choice)
  ├── gameweek > 0  →  CollectFPLData (backfill mode)
  └── default       →  ResolveGameweek → CheckShouldRun → PrepareResolvedInput → CollectFPLData
```

EventBridge now sends `gameweek: 0` to trigger auto-resolution.

## Testing
- `terraform validate` passes
- `terraform fmt -check` clean