### PR TITLE
fix(enrich): include prompt templates as package data

### DIFF
--- a/services/enrich/pyproject.toml
+++ b/services/enrich/pyproject.toml
@@ -24,3 +24,6 @@ dev = [
 
 [tool.setuptools.packages.find]
 where = ["src"]
+
+[tool.setuptools.package-data]
+fpl_enrich = ["prompts/**/*.txt"]


### PR DESCRIPTION
## What
Add `[tool.setuptools.package-data]` to include `prompts/**/*.txt` in the installed package.

## Why
The enrichment Lambda failed with:
```
FileNotFoundError: /usr/local/lib/python3.11/site-packages/fpl_enrich/prompts/v1/player_summary.txt
```
Setuptools only includes `.py` files by default. The `.txt` prompt templates were missing from the Docker image.

## Testing
One-line config change — verified the glob pattern matches all 4 prompt files.