### PR TITLE
fix(data): use realistic User-Agent for FPL API requests

### DIFF
--- a/services/data/src/fpl_data/collectors/fpl_api_collector.py
+++ b/services/data/src/fpl_data/collectors/fpl_api_collector.py
@@ -186,7 +186,10 @@ class FPLAPICollector:
         """Fetch JSON from the FPL API."""
         logger.info("[FPL API] GET %s", url)
         async with httpx.AsyncClient(
-            headers={"User-Agent": "Mozilla/5.0 (compatible; FPL-Platform/1.0)"},
+            headers={
+                "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+                "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36",
+            },
             timeout=30.0,
         ) as client:
             response = await client.get(url)

--- a/services/data/src/fpl_data/collectors/gameweek_resolver.py
+++ b/services/data/src/fpl_data/collectors/gameweek_resolver.py
@@ -43,7 +43,10 @@ async def resolve_gameweek(season: str = "2025-26") -> GameweekInfo:
         ValueError: If no gameweek data is found in the API response.
     """
     async with httpx.AsyncClient(
-        headers={"User-Agent": "Mozilla/5.0 (compatible; FPL-Platform/1.0)"},
+        headers={
+            "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+            "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36",
+        },
         timeout=30.0,
     ) as client:
         response = await client.get(FPL_BOOTSTRAP_URL)


### PR DESCRIPTION
## Summary
- FPL API Cloudflare blocks `FPL-Platform/1.0` User-Agent from AWS Lambda IPs on first request (not a rate/duplicate issue)
- Switch to realistic Chrome UA string in both FPL API collector and gameweek resolver

Closes #64

## Test plan
- [x] 53 data tests pass
- [ ] Deploy and re-run GW31 backfill

🤖 Generated with [Claude Code](https://claude.com/claude-code)