### PR TITLE
feat(infra): CloudFront cache invalidation on pipeline success

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- CloudFront cache invalidation: EventBridge rule triggers a Lambda to invalidate `/api/v1/*` when the pipeline succeeds, so the dashboard serves fresh data immediately
 - Dashboard v4: Captain Picker Decision Matrix page with weighted composite captaincy score
 - Dashboard v4: Differential Radar page — scatter plot + card grid for low-ownership high-value players with sparklines
 - Dashboard v4: Transfer Planner page — side-by-side player comparison with budget simulation, score pyramid, and form sparklines

--- a/docs/adr/0007-static-dashboard-architecture.md
+++ b/docs/adr/0007-static-dashboard-architecture.md
@@ -80,6 +80,10 @@ s3://fpl-data-lake-dev/public/api/v1/
 
 Files are versioned by gameweek but the `latest` path always points to the most recent data. Total payload is ~250 KB — small enough to serve entirely from CloudFront edge cache.
 
+### Cache invalidation
+
+CloudFront caches `/api/v1/*` responses at the edge. Without explicit invalidation, users could see stale data for up to 24 hours after a pipeline run. Rather than embedding invalidation logic inside the Step Function (which would couple pipeline orchestration to CDN concerns), an EventBridge rule reacts to the pipeline's `SUCCEEDED` status and triggers a lightweight Lambda that calls `cloudfront:CreateInvalidation` on `/api/v1/*`. This keeps the pipeline's responsibility limited to producing data, and the invalidation concern decoupled and independently testable.
+
 ## Consequences
 
 **Easier:**

--- a/infrastructure/environments/dev/main.tf
+++ b/infrastructure/environments/dev/main.tf
@@ -482,6 +482,103 @@ resource "aws_iam_role_policy" "eventbridge_sfn_start" {
   })
 }
 
+# -----------------------------------------------------------------------------
+# CloudFront Cache Invalidation — EventBridge reacts to pipeline success
+# -----------------------------------------------------------------------------
+data "archive_file" "invalidate_cache" {
+  type        = "zip"
+  source_file = "../../lambdas/invalidate_cache/handler.py"
+  output_path = "../../lambdas/invalidate_cache/handler.zip"
+}
+
+resource "aws_lambda_function" "invalidate_cache" {
+  function_name    = "fpl-${var.environment}-invalidate-cache"
+  role             = aws_iam_role.invalidate_cache.arn
+  handler          = "handler.lambda_handler"
+  runtime          = "python3.11"
+  timeout          = 30
+  memory_size      = 128
+  filename         = data.archive_file.invalidate_cache.output_path
+  source_code_hash = data.archive_file.invalidate_cache.output_base64sha256
+
+  environment {
+    variables = {
+      CLOUDFRONT_DISTRIBUTION_ID = module.web_hosting.cloudfront_distribution_id
+    }
+  }
+}
+
+resource "aws_cloudwatch_log_group" "invalidate_cache" {
+  name              = "/aws/lambda/fpl-${var.environment}-invalidate-cache"
+  retention_in_days = 30
+}
+
+resource "aws_iam_role" "invalidate_cache" {
+  name = "fpl-${var.environment}-invalidate-cache-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "lambda.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "invalidate_cache_basic" {
+  role       = aws_iam_role.invalidate_cache.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+resource "aws_iam_role_policy" "invalidate_cache_cloudfront" {
+  name = "fpl-${var.environment}-invalidate-cache-cloudfront"
+  role = aws_iam_role.invalidate_cache.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["cloudfront:CreateInvalidation"]
+        Resource = "arn:aws:cloudfront::*:distribution/${module.web_hosting.cloudfront_distribution_id}"
+      }
+    ]
+  })
+}
+
+# EventBridge rule: fires when the collection pipeline execution succeeds
+resource "aws_cloudwatch_event_rule" "pipeline_succeeded" {
+  name        = "fpl-pipeline-succeeded-${var.environment}"
+  description = "Fires when the FPL collection pipeline completes successfully"
+
+  event_pattern = jsonencode({
+    source      = ["aws.states"]
+    detail-type = ["Step Functions Execution Status Change"]
+    detail = {
+      status          = ["SUCCEEDED"]
+      stateMachineArn = [module.pipeline.state_machine_arn]
+    }
+  })
+}
+
+resource "aws_cloudwatch_event_target" "invalidate_cache" {
+  rule = aws_cloudwatch_event_rule.pipeline_succeeded.name
+  arn  = aws_lambda_function.invalidate_cache.arn
+}
+
+resource "aws_lambda_permission" "eventbridge_invalidate_cache" {
+  statement_id  = "AllowEventBridgeInvoke"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.invalidate_cache.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.pipeline_succeeded.arn
+}
+
 resource "aws_iam_role_policy" "lambda_sns" {
   name = "fpl-lambda-sns-${var.environment}"
   role = aws_iam_role.lambda_standard.id

--- a/infrastructure/lambdas/invalidate_cache/handler.py
+++ b/infrastructure/lambdas/invalidate_cache/handler.py
@@ -1,0 +1,52 @@
+"""Lambda handler to invalidate CloudFront cache after a successful pipeline run.
+
+Triggered by EventBridge when the Step Functions pipeline execution succeeds.
+Invalidates the /api/v1/* path pattern so the dashboard serves fresh data.
+"""
+
+import logging
+import os
+import time
+from typing import Any
+
+import boto3
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+cloudfront = boto3.client("cloudfront")
+
+
+def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
+    """Create a CloudFront cache invalidation for dashboard data paths.
+
+    Args:
+        event: EventBridge event for Step Functions execution status change.
+        context: Lambda context (unused).
+
+    Returns:
+        Dict with invalidation ID and status.
+    """
+    distribution_id = os.environ["CLOUDFRONT_DISTRIBUTION_ID"]
+
+    logger.info(
+        "Pipeline succeeded — invalidating CloudFront distribution %s",
+        distribution_id,
+    )
+
+    response = cloudfront.create_invalidation(
+        DistributionId=distribution_id,
+        InvalidationBatch={
+            "Paths": {"Quantity": 1, "Items": ["/api/v1/*"]},
+            "CallerReference": f"pipeline-{int(time.time())}",
+        },
+    )
+
+    invalidation_id = response["Invalidation"]["Id"]
+    logger.info("Invalidation created: %s", invalidation_id)
+
+    return {
+        "statusCode": 200,
+        "invalidationId": invalidation_id,
+        "distributionId": distribution_id,
+    }


### PR DESCRIPTION
## Summary
- Adds an EventBridge rule that fires when the Step Functions pipeline execution succeeds
- Triggers a lightweight zip-packaged Lambda that invalidates CloudFront `/api/v1/*` so the dashboard serves fresh data immediately after a pipeline run
- Uses a dedicated IAM role scoped to `cloudfront:CreateInvalidation` only (least privilege)
- Updates ADR-7 with cache invalidation rationale (decoupled from pipeline via EventBridge — SRP)

## Design
```
Pipeline succeeds
  → EventBridge (Step Functions Execution Status Change)
    → invalidate-cache Lambda
      → CloudFront invalidates /api/v1/*
```

Decoupled from the Step Function itself so the pipeline's only job is producing data. If a second pipeline or manual backfill writes to the same prefix, adding another EventBridge rule is trivial.

## Files
- `infrastructure/lambdas/invalidate_cache/handler.py` — Lambda handler (zip-packaged, no ECR)
- `infrastructure/environments/dev/main.tf` — Terraform resources (Lambda, IAM, EventBridge rule + target)
- `docs/adr/0007-static-dashboard-architecture.md` — Cache invalidation section added
- `CHANGELOG.md` — Entry under [Unreleased]

## Test plan
- [ ] `terraform plan` shows expected resources (Lambda, IAM role, EventBridge rule, EventBridge target, Lambda permission)
- [ ] Deploy to dev, trigger pipeline manually, confirm CloudFront invalidation appears in AWS console
- [ ] Verify dashboard serves updated data within minutes of pipeline completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)