### PR TITLE
chore: add Langfuse observability to curate service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Langfuse observability for curation service — `@observe(name="curate_gameweek")` tracing on the handler, matching the enrichment layer pattern
+- Bootstrap infra comment documenting rationale for `AdministratorAccess` policy with OIDC-scoped trust
 - CloudFront cache invalidation: EventBridge rule triggers a Lambda to invalidate `/api/v1/*` when the pipeline succeeds, so the dashboard serves fresh data immediately
 - Dashboard v4: Captain Picker Decision Matrix page with weighted composite captaincy score
 - Dashboard v4: Differential Radar page — scatter plot + card grid for low-ownership high-value players with sparklines

--- a/infrastructure/bootstrap/main.tf
+++ b/infrastructure/bootstrap/main.tf
@@ -104,6 +104,8 @@ resource "aws_iam_role" "cicd" {
   assume_role_policy = data.aws_iam_policy_document.github_actions_assume.json
 }
 
+# AdministratorAccess: acceptable for personal dev account with OIDC-scoped trust.
+# Production would use least-privilege policies per service 
 resource "aws_iam_role_policy_attachment" "cicd_admin" {
   role       = aws_iam_role.cicd.name
   policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"

--- a/services/curate/pyproject.toml
+++ b/services/curate/pyproject.toml
@@ -9,6 +9,7 @@ description = "FPL data curation service — derives dashboard-ready datasets fr
 requires-python = ">=3.11"
 dependencies = [
     "fpl-lib",
+    "langfuse>=2.0.0",
     "pandas>=2.0.0",
     "pyarrow>=14.0.0",
 ]

--- a/services/curate/src/fpl_curate/config.py
+++ b/services/curate/src/fpl_curate/config.py
@@ -22,6 +22,8 @@ DEFAULT_FPL_SCORE_WEIGHTS: dict[str, float] = {
 class CurateSettings(FPLSettings):
     """Settings for the curation service."""
 
+    LANGFUSE_PUBLIC_KEY: str = ""
+    LANGFUSE_SECRET_KEY: str = ""
     FPL_SCORE_WEIGHTS: dict[str, float] = DEFAULT_FPL_SCORE_WEIGHTS
 
 

--- a/services/curate/src/fpl_curate/handlers/curate_all.py
+++ b/services/curate/src/fpl_curate/handlers/curate_all.py
@@ -4,6 +4,7 @@ import logging
 from typing import Any
 
 import pyarrow as pa
+from langfuse import observe
 
 from fpl_curate.config import get_curate_settings
 from fpl_curate.curators.fixture_ticker import build_fixture_ticker, build_team_map
@@ -24,6 +25,23 @@ OPTIONAL_PARAMS = ["output_bucket", "force"]
 SCHEMA_VERSION = "1.0.0"
 
 
+def _init_langfuse(region: str = "eu-west-2") -> None:
+    """Initialise Langfuse with keys from Secrets Manager."""
+    import os
+
+    import boto3
+
+    if not os.environ.get("LANGFUSE_PUBLIC_KEY"):
+        client = boto3.client("secretsmanager", region_name=region)
+        resp = client.get_secret_value(SecretId="/fpl-platform/dev/langfuse-public-key")
+        os.environ["LANGFUSE_PUBLIC_KEY"] = resp["SecretString"]
+    if not os.environ.get("LANGFUSE_SECRET_KEY"):
+        client = boto3.client("secretsmanager", region_name=region)
+        resp = client.get_secret_value(SecretId="/fpl-platform/dev/langfuse-secret-key")
+        os.environ["LANGFUSE_SECRET_KEY"] = resp["SecretString"]
+
+
+@observe(name="curate_gameweek")
 async def main(
     season: str,
     gameweek: int,
@@ -210,6 +228,7 @@ async def main(
 
 def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
     """AWS Lambda entry point for data curation."""
+    _init_langfuse()
     return RunHandler(
         main_func=main,
         required_main_params=REQUIRED_PARAMS,


### PR DESCRIPTION
## Summary
- **Curate Langfuse tracing**: Adds `@observe(name="curate_gameweek")` to the curation handler, `_init_langfuse()` for Secrets Manager key loading, and `langfuse>=2.0.0` as a dependency — matching the pattern already established in the enrichment service
- **Bootstrap IAM comment**: Documents the `AdministratorAccess` policy rationale (personal dev account with OIDC-scoped trust) in `bootstrap/main.tf`
- CHANGELOG updated

## Test plan
- [ ] Verify `make lint` passes with the new import
- [ ] Confirm curate Lambda deploys with langfuse dependency
- [ ] Check Langfuse dashboard shows `curate_gameweek` traces after a pipeline run

🤖 Generated with [Claude Code](https://claude.com/claude-code)