### PR TITLE
fix(web): dashboard chart UX fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Dashboard: Trends page — removed flat-line metrics (price, ownership, form, pts/m) that showed identical values across gameweeks due to bootstrap snapshot reuse; chart now tracks FPL Score only
+- Dashboard: xG Efficiency scatter — axis labels showed corrupted numbers; capped domain to 99th percentile and added tick formatting
+- Dashboard: Differential Radar scatter — player name missing from hover tooltip; replaced default tooltip with custom content renderer
+
+### Changed
+- Dashboard: Moved xG Efficiency, Ownership vs Value, and Momentum Heatmap charts above the player rankings table for better visibility
+
 ### Added
 - Langfuse observability for curation service — `@observe(name="curate_gameweek")` tracing on the handler, matching the enrichment layer pattern
 - Bootstrap infra comment documenting rationale for `AdministratorAccess` policy with OIDC-scoped trust

--- a/web/dashboard/src/pages/DifferentialsPage.tsx
+++ b/web/dashboard/src/pages/DifferentialsPage.tsx
@@ -326,17 +326,18 @@ export function DifferentialsPage() {
                   }}
                 />
                 <Tooltip
-                  contentStyle={TOOLTIP_STYLE}
-                  formatter={(value: unknown, name: unknown) => {
-                    const v = Number(value);
-                    const n = String(name);
-                    if (n === "Ownership") return [`${v.toFixed(1)}%`, n];
-                    if (n === "FPL Score") return [v.toFixed(1), n];
-                    return [v, n];
+                  content={({ active, payload }) => {
+                    if (!active || !payload?.[0]) return null;
+                    const d = payload[0].payload;
+                    return (
+                      <div className="rounded-lg border border-[var(--border)] bg-[var(--card)] p-2 shadow-lg text-xs" style={TOOLTIP_STYLE}>
+                        <p className="font-semibold">{d.web_name} ({d.position})</p>
+                        <p className="text-[var(--muted-foreground)]">
+                          FPL Score: {d.fpl_score.toFixed(1)} | Own: {d.ownership_pct.toFixed(1)}%
+                        </p>
+                      </div>
+                    );
                   }}
-                  labelFormatter={(_: unknown, payload: ReadonlyArray<{ payload?: { web_name?: string } }>) =>
-                    payload?.[0]?.payload?.web_name ?? ""
-                  }
                 />
                 {/* Reference lines at medians */}
                 <ReferenceLine

--- a/web/dashboard/src/pages/players/PlayersPage.tsx
+++ b/web/dashboard/src/pages/players/PlayersPage.tsx
@@ -323,6 +323,14 @@ export function PlayersPage() {
         </Card>
       </div>
 
+      {/* Visual Insights */}
+      <div className="grid gap-4 md:grid-cols-2">
+        <XgScatter players={data.players} />
+        <OwnershipBubble players={data.players} />
+      </div>
+
+      {data.history.length > 0 && <MomentumHeatmap history={data.history} />}
+
       {/* Table Controls */}
       <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3">
         <h1 className="text-2xl font-bold">Player Rankings</h1>
@@ -460,11 +468,6 @@ export function PlayersPage() {
           </table>
         </div>
       </Card>
-
-      <XgScatter players={filtered} />
-      <OwnershipBubble players={filtered} />
-
-      {data.history.length > 0 && <MomentumHeatmap history={data.history} />}
 
       {filtered.length === 0 && (
         <div className="text-center py-12 text-[var(--muted-foreground)]">

--- a/web/dashboard/src/pages/players/XgScatter.tsx
+++ b/web/dashboard/src/pages/players/XgScatter.tsx
@@ -30,7 +30,10 @@ export function XgScatter({ players }: { players: PlayerDashboard[] }) {
     delta: Math.abs(p.goals_scored - p.xg!),
   }));
 
-  const maxVal = Math.max(...scatterData.map((d) => Math.max(d.x, d.y)), 1);
+  // Cap axis to 99th percentile to avoid outlier-stretched axes
+  const allVals = scatterData.flatMap((d) => [d.x, d.y]).sort((a, b) => a - b);
+  const p99 = allVals[Math.floor(allVals.length * 0.99)] ?? 1;
+  const maxVal = Math.ceil(p99 + 1);
 
   // Label top 5 outliers by distance from the reference line
   const outlierNames = new Set(
@@ -58,10 +61,10 @@ export function XgScatter({ players }: { players: PlayerDashboard[] }) {
         <ResponsiveContainer width="100%" height={350}>
           <ScatterChart margin={{ top: 10, right: 20, bottom: 30, left: 10 }}>
             <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" opacity={0.5} />
-            <XAxis type="number" dataKey="x" name="xG" domain={[0, maxVal]} tick={{ fontSize: 11, fill: "var(--muted-foreground)" }}>
+            <XAxis type="number" dataKey="x" name="xG" domain={[0, maxVal]} tickFormatter={(v) => Math.round(v).toString()} tick={{ fontSize: 11, fill: "var(--muted-foreground)" }}>
               <Label value="Expected Goals (xG)" position="bottom" offset={15} style={{ fontSize: 12, fill: "var(--muted-foreground)" }} />
             </XAxis>
-            <YAxis type="number" dataKey="y" name="Goals" domain={[0, maxVal]} tick={{ fontSize: 11, fill: "var(--muted-foreground)" }}>
+            <YAxis type="number" dataKey="y" name="Goals" domain={[0, maxVal]} tickFormatter={(v) => Math.round(v).toString()} tick={{ fontSize: 11, fill: "var(--muted-foreground)" }}>
               <Label value="Actual Goals" angle={-90} position="insideLeft" offset={-5} style={{ fontSize: 12, fill: "var(--muted-foreground)" }} />
             </YAxis>
             <ZAxis type="number" dataKey="minutes" range={[30, 200]} name="Minutes" />

--- a/web/dashboard/src/pages/trends/TrendsPage.tsx
+++ b/web/dashboard/src/pages/trends/TrendsPage.tsx
@@ -20,29 +20,21 @@ import { TableSkeleton } from "@/components/ui/skeleton";
 import { ErrorCard } from "@/components/ui/error-card";
 import {
   cn,
-  formatPrice,
   positionColor,
   scoreColor,
   CHART_COLORS,
   TOOLTIP_STYLE,
 } from "@/lib/utils";
 
-type Metric = "fpl_score" | "price" | "ownership_pct" | "form" | "points_per_million";
-
-const METRICS: { key: Metric; label: string; format: (v: number) => string }[] = [
-  { key: "fpl_score", label: "FPL Score", format: (v) => v.toFixed(1) },
-  { key: "price", label: "Price", format: (v) => formatPrice(v) },
-  { key: "ownership_pct", label: "Ownership", format: (v) => `${v.toFixed(1)}%` },
-  { key: "form", label: "Form", format: (v) => v.toFixed(1) },
-  { key: "points_per_million", label: "Pts/M", format: (v) => v.toFixed(1) },
-];
+const METRIC_LABEL = "FPL Score";
+const METRIC_KEY = "fpl_score" as const;
+const METRIC_FORMAT = (v: number) => v.toFixed(1);
 
 export function TrendsPage() {
   const { data, loading, error } = useApi(() => api.history(), [] as PlayerHistory[]);
 
   const [searchParams, setSearchParams] = useSearchParams();
   const search = searchParams.get("q") ?? "";
-  const metric = (searchParams.get("metric") as Metric) ?? "fpl_score";
 
   const selectedParam = searchParams.get("ids");
   const selected = useMemo(
@@ -54,12 +46,6 @@ export function TrendsPage() {
     const next = new URLSearchParams(searchParams);
     if (q) next.set("q", q);
     else next.delete("q");
-    setSearchParams(next, { replace: true });
-  };
-
-  const setMetric = (m: Metric) => {
-    const next = new URLSearchParams(searchParams);
-    next.set("metric", m);
     setSearchParams(next, { replace: true });
   };
 
@@ -101,11 +87,11 @@ export function TrendsPage() {
         const row = data.find((r) => r.player_id === pid && r.gameweek === gw);
         const player = players.find((p) => p.player_id === pid);
         const key = player?.web_name ?? `Player ${pid}`;
-        point[key] = row?.[metric] ?? 0;
+        point[key] = row?.[METRIC_KEY] ?? 0;
       });
       return point;
     });
-  }, [data, gameweeks, selected, metric, players]);
+  }, [data, gameweeks, selected, players]);
 
   const selectedNames = selected.map(
     (pid) => players.find((p) => p.player_id === pid)?.web_name ?? "",
@@ -149,8 +135,6 @@ export function TrendsPage() {
       </div>
     );
   }
-
-  const metricConfig = METRICS.find((m) => m.key === metric)!;
 
   return (
     <div className="space-y-6">
@@ -324,28 +308,9 @@ export function TrendsPage() {
         <div className="md:col-span-9">
           <Card className="h-full">
             <CardHeader>
-              <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-2">
-                <CardTitle>
-                  {selected.length === 0 ? "Select players to compare" : `${metricConfig.label} over time`}
-                </CardTitle>
-                <div className="flex gap-1 flex-wrap" role="group" aria-label="Select metric">
-                  {METRICS.map((m) => (
-                    <button
-                      key={m.key}
-                      onClick={() => setMetric(m.key)}
-                      className={cn(
-                        "rounded-md px-2.5 py-1 text-xs font-medium transition-colors",
-                        metric === m.key
-                          ? "bg-[var(--accent)] text-[var(--accent-foreground)]"
-                          : "bg-[var(--muted)] text-[var(--muted-foreground)] hover:bg-[var(--border)]",
-                      )}
-                      aria-pressed={metric === m.key}
-                    >
-                      {m.label}
-                    </button>
-                  ))}
-                </div>
-              </div>
+              <CardTitle>
+                {selected.length === 0 ? "Select players to compare" : `${METRIC_LABEL} over time`}
+              </CardTitle>
             </CardHeader>
             <CardContent>
               {selected.length === 0 ? (
@@ -360,7 +325,7 @@ export function TrendsPage() {
                     <YAxis tick={{ fontSize: 11, fill: "var(--muted-foreground)" }} domain={["auto", "auto"]} />
                     <Tooltip
                       contentStyle={TOOLTIP_STYLE}
-                      formatter={(value) => metricConfig.format(Number(value))}
+                      formatter={(value) => METRIC_FORMAT(Number(value))}
                     />
                     {selectedNames.map((name, i) => (
                       <Line


### PR DESCRIPTION
## Summary
- **Trends page**: Removed flat-line metrics (price, ownership, form, pts/m) that showed identical values across gameweeks due to bootstrap snapshot reuse — chart now tracks FPL Score only
- **Players page**: Moved xG Efficiency, Ownership vs Value, and Momentum Heatmap charts above the rankings table so they're not buried below 300 rows
- **xG Scatter**: Fixed corrupted axis labels by capping domain to 99th percentile with integer tick formatting
- **Differential Radar**: Fixed missing player name on scatter tooltip — replaced default Recharts tooltip with custom content renderer

## Test plan
- [ ] Trends page: verify chart shows only FPL Score, no metric toggle buttons
- [ ] Players page: verify scatter charts and heatmap appear between hero cards and rankings table
- [ ] xG Scatter: verify Y-axis shows clean integer labels, no corrupted numbers
- [ ] Differentials page: hover any dot on scatter chart and confirm player name + position shown
- [ ] Run `npx tsc --noEmit` — passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)