### PR TITLE
docs(adr): add SSR as rejected option in ADR-0007

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- ADR-0007: Added SSR (Next.js/Remix) as explicitly rejected option — documents why server-side rendering is unnecessary for a weekly-refresh personal dashboard
+
 ### Fixed
 - Dashboard: Trends page — removed flat-line metrics (price, ownership, form, pts/m) that showed identical values across gameweeks due to bootstrap snapshot reuse; chart now tracks FPL Score only
 - Dashboard: xG Efficiency scatter — axis labels showed corrupted numbers; capped domain to 99th percentile and added tick formatting

--- a/docs/adr/0007-static-dashboard-architecture.md
+++ b/docs/adr/0007-static-dashboard-architecture.md
@@ -23,7 +23,12 @@ React frontend calling a FastAPI service that reads curated Parquet from S3 via 
 
 Rejected because: The data updates weekly — a persistent API adds infrastructure cost and operational complexity (Lambda cold starts, or always-on ECS/EC2) for no functional benefit. Every dashboard request would query identical data. The API layer is justified when the LangGraph agent arrives in Phase 2, not before.
 
-### 3. React SPA with pre-generated JSON on CloudFront (chosen)
+### 3. Server-side rendered React (Next.js / Remix) (rejected)
+React framework with SSR — HTML is generated on a server per request, improving SEO and initial load performance.
+
+Rejected because: SSR requires persistent compute (Lambda@Edge, ECS, or a Node.js server) to render pages on every request. The dashboard has no user-specific data, no auth, and updates weekly — every visitor sees identical content, so generating HTML per request is pure waste. SSR's SEO advantage is irrelevant for a personal analytics tool that doesn't need search engine indexing. The operational overhead (Node.js runtime, server monitoring, cold starts) contradicts the project's goal of zero-compute hosting.
+
+### 4. React SPA with pre-generated JSON on CloudFront (chosen)
 Static React app and pre-computed JSON data files, both served from S3 behind CloudFront.
 
 ## Decision


### PR DESCRIPTION
## Summary
- Added server-side rendering (Next.js/Remix) as an explicitly rejected option in ADR-0007
- Documents why SSR is unnecessary: no user-specific data, weekly refresh cycle, zero-compute hosting goal
- Renumbered the chosen option from #3 to #4

## Test plan
- [ ] Verify ADR markdown renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)