### PR TITLE
fix(data): use curl_cffi to bypass Cloudflare 403s on Lambda

### DIFF
--- a/services/data/pyproject.toml
+++ b/services/data/pyproject.toml
@@ -10,6 +10,7 @@ requires-python = ">=3.11"
 dependencies = [
     "fpl-lib",
     "httpx>=0.27.0",
+    "curl_cffi>=0.7.0",
     "beautifulsoup4>=4.12.0",
     "feedparser>=6.0.0",
     "pandas>=2.0.0",

--- a/services/data/src/fpl_data/collectors/fpl_api_collector.py
+++ b/services/data/src/fpl_data/collectors/fpl_api_collector.py
@@ -1,13 +1,16 @@
 """Collector for the official FPL API.
 
 FPL API is public, no auth required. Base URL: https://fantasy.premierleague.com/api
+
+Uses curl_cffi to impersonate Chrome's TLS fingerprint, which prevents
+Cloudflare from blocking requests originating from AWS Lambda IPs.
 """
 
 import asyncio
 import logging
 from datetime import UTC, datetime
 
-import httpx
+from curl_cffi.requests import AsyncSession
 
 from fpl_lib.clients.s3 import S3Client
 from fpl_lib.core.responses import CollectionResponse
@@ -186,19 +189,13 @@ class FPLAPICollector:
     async def _fetch(self, url: str, max_retries: int = 5) -> dict | list:
         """Fetch JSON from the FPL API with exponential backoff.
 
-        Cloudflare may block AWS Lambda IPs on initial attempts but
-        allow retries after a delay.
+        Uses curl_cffi with Chrome TLS impersonation to bypass Cloudflare
+        fingerprint-based blocking on AWS Lambda IPs.
         """
-        async with httpx.AsyncClient(
-            headers={
-                "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
-                "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36",
-            },
-            timeout=30.0,
-        ) as client:
+        async with AsyncSession(impersonate="chrome", timeout=30) as session:
             for attempt in range(max_retries):
                 logger.info("[FPL API] GET %s (attempt %d/%d)", url, attempt + 1, max_retries)
-                response = await client.get(url)
+                response = await session.get(url)
                 logger.info(
                     "[FPL API] %s | status=%d | size=%d bytes",
                     url.split("/api/")[-1],

--- a/services/data/src/fpl_data/collectors/gameweek_resolver.py
+++ b/services/data/src/fpl_data/collectors/gameweek_resolver.py
@@ -2,11 +2,14 @@
 
 The FPL API bootstrap-static endpoint contains an `events` array where each
 event has `id` (gameweek number), `finished` (bool), and `is_current` (bool).
+
+Uses curl_cffi to impersonate Chrome's TLS fingerprint, which prevents
+Cloudflare from blocking requests originating from AWS Lambda IPs.
 """
 
 import logging
 
-import httpx
+from curl_cffi.requests import AsyncSession
 
 logger = logging.getLogger(__name__)
 
@@ -42,14 +45,8 @@ async def resolve_gameweek(season: str = "2025-26") -> GameweekInfo:
     Raises:
         ValueError: If no gameweek data is found in the API response.
     """
-    async with httpx.AsyncClient(
-        headers={
-            "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
-            "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36",
-        },
-        timeout=30.0,
-    ) as client:
-        response = await client.get(FPL_BOOTSTRAP_URL)
+    async with AsyncSession(impersonate="chrome", timeout=30) as session:
+        response = await session.get(FPL_BOOTSTRAP_URL)
         response.raise_for_status()
         data = response.json()
 

--- a/services/data/tests/test_fpl_api_collector.py
+++ b/services/data/tests/test_fpl_api_collector.py
@@ -2,8 +2,8 @@
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import httpx
 import pytest
+from curl_cffi.requests import Response as CurlResponse
 
 from fpl_data.collectors.fpl_api_collector import FPL_BASE_URL, FPLAPICollector
 
@@ -63,10 +63,21 @@ def player_history_response() -> dict:
     }
 
 
-def _mock_response(data: dict | list, status_code: int = 200) -> httpx.Response:
-    """Create a mock httpx.Response."""
-    request = httpx.Request("GET", "https://example.com")
-    response = httpx.Response(status_code=status_code, json=data, request=request)
+def _mock_curl_response(data: dict | list, status_code: int = 200) -> MagicMock:
+    """Create a mock curl_cffi Response."""
+    import json
+
+    response = MagicMock(spec=CurlResponse)
+    response.status_code = status_code
+    response.content = json.dumps(data).encode()
+    response.json.return_value = data
+    response.raise_for_status = MagicMock()
+    if status_code >= 400:
+        from curl_cffi.requests.errors import RequestsError
+
+        response.raise_for_status.side_effect = RequestsError(
+            f"HTTP {status_code}", code=status_code
+        )
     return response
 
 
@@ -130,14 +141,14 @@ async def test_collect_bootstrap_force_overwrites(
 async def test_collect_bootstrap_raises_on_http_error(
     collector: FPLAPICollector,
 ) -> None:
+    from curl_cffi.requests.errors import RequestsError
+
     async def _raise_500(url: str) -> None:
-        request = httpx.Request("GET", url)
-        response = httpx.Response(500, request=request)
-        raise httpx.HTTPStatusError("Server error", request=request, response=response)
+        raise RequestsError("HTTP 500", code=500)
 
     with (
         patch.object(collector, "_fetch", side_effect=_raise_500),
-        pytest.raises(httpx.HTTPStatusError),
+        pytest.raises(RequestsError),
     ):
         await collector.collect_bootstrap("2025-26")
 
@@ -289,10 +300,18 @@ async def test_fetch_calls_correct_url(
     collector: FPLAPICollector,
     bootstrap_response: dict,
 ) -> None:
-    mock_response = _mock_response(bootstrap_response)
-    with patch("httpx.AsyncClient.get", new_callable=AsyncMock, return_value=mock_response):
+    mock_response = _mock_curl_response(bootstrap_response)
+    mock_session = AsyncMock()
+    mock_session.get = AsyncMock(return_value=mock_response)
+
+    with patch(
+        "fpl_data.collectors.fpl_api_collector.AsyncSession",
+    ) as mock_cls:
+        mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
         data = await collector._fetch(f"{FPL_BASE_URL}/bootstrap-static/")
 
+    mock_session.get.assert_called_once_with(f"{FPL_BASE_URL}/bootstrap-static/")
     assert data["elements"] == bootstrap_response["elements"]
 
 
@@ -301,11 +320,20 @@ async def test_fetch_calls_correct_url(
 async def test_fetch_raises_on_server_error(
     collector: FPLAPICollector,
 ) -> None:
-    mock_response = _mock_response({}, status_code=500)
+    from curl_cffi.requests.errors import RequestsError
+
+    mock_response = _mock_curl_response({}, status_code=500)
+    mock_session = AsyncMock()
+    mock_session.get = AsyncMock(return_value=mock_response)
+
     with (
-        patch("httpx.AsyncClient.get", new_callable=AsyncMock, return_value=mock_response),
-        pytest.raises(httpx.HTTPStatusError),
+        patch(
+            "fpl_data.collectors.fpl_api_collector.AsyncSession",
+        ) as mock_cls,
+        pytest.raises(RequestsError),
     ):
+        mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
         await collector._fetch(f"{FPL_BASE_URL}/bootstrap-static/")
 
 


### PR DESCRIPTION
## Summary
- Replace `httpx` with `curl_cffi` (Chrome TLS impersonation) in `fpl_api_collector.py` and `gameweek_resolver.py` to bypass Cloudflare fingerprint-based blocking from AWS Lambda IPs
- Add `curl_cffi>=0.7.0` to data service dependencies
- Update unit tests to mock `curl_cffi` instead of `httpx`

## Context
The FPL API sits behind Cloudflare which fingerprints TLS handshakes. Python's standard TLS stack (used by `httpx`) gets detected and blocked with 403 Forbidden when requests originate from AWS Lambda IPs. `curl_cffi` impersonates Chrome's full TLS fingerprint, making requests indistinguishable from a real browser.

`httpx` is retained as a dependency since `understat_collector.py` still uses it (Understat doesn't have this issue).

## Test plan
- [x] All 16 existing tests in `test_fpl_api_collector.py` pass
- [ ] Deploy to DEV and verify FPL API calls succeed without 403s
- [ ] Monitor CloudWatch logs for retry/backoff patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)