### PR TITLE
feat(enrich): add Langfuse session IDs, metadata, and quality scores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Langfuse session IDs (`{season}-gw{gameweek}`) on all enrichment and curation traces — enables grouping all traces for a gameweek run in a single Langfuse session view
+- Langfuse metadata (enricher name, prompt version, model, batch size) on every `enricher_batch_call` observation — enables filtering and comparing traces by enricher or prompt version
+- Langfuse `output_count_valid` score on each LLM batch call — flags when the model returns fewer items than requested
+- Langfuse `validation_pass_rate` score on each enricher trace — tracks what percentage of LLM outputs pass Pydantic validation
+
 ### Changed
 - ADR-0007: Added SSR (Next.js/Remix) as explicitly rejected option — documents why server-side rendering is unnecessary for a weekly-refresh personal dashboard
 

--- a/docs/adr/0005-prompt-versioning-and-llm-observability.md
+++ b/docs/adr/0005-prompt-versioning-and-llm-observability.md
@@ -71,26 +71,65 @@ services/enrich/src/fpl_enrich/prompts/
 **Deployment:** The `prompt_version` default is in the Lambda handler. To roll out a new version, either update the Step Functions state machine input or the handler default. Prompts are additive — v1 still works after v2 is deployed, so a forgotten parameter update is safe (just stale).
 
 ### LLM observability with Langfuse
-Integration via the `@observe` decorator on enricher methods and the Lambda handler:
+Integration via the `@observe` decorator on enricher methods and Lambda handlers. Session IDs and trace-level metadata are set via `propagate_attributes` in each Lambda entry point, which propagates to all child spans created within that context.
 
+**Session and metadata setup** (Lambda handler level):
 ```python
+from langfuse import observe, propagate_attributes
+
+def lambda_handler(event, context):
+    _init_langfuse()
+    season = event.get("season", "unknown")
+    gameweek = event.get("gameweek", 0)
+    with propagate_attributes(
+        session_id=f"{season}-gw{gameweek}",
+        metadata={"enricher": "player_summary", "prompt_version": event.get("prompt_version", "v1")},
+    ):
+        return RunHandler(main_func=main, ...).lambda_executor(lambda_event=event)
+```
+
+**Batch-level metadata and scoring** (base enricher):
+```python
+from langfuse import Langfuse, observe
+
 @observe(name="enricher_batch_call")
-def _call_llm(self, batch: list[dict]) -> list[dict]:
-    langfuse_context.update_current_observation(
-        metadata={"enricher": self.__class__.__name__, "prompt_version": self.prompt_version}
+async def _call_llm(self, batch: list[dict]) -> list[dict]:
+    langfuse = Langfuse()
+    langfuse.update_current_span(
+        metadata={
+            "enricher": self.__class__.__name__,
+            "prompt_version": self.prompt_version,
+            "model": self.MODEL,
+            "batch_size": len(batch),
+        },
     )
-    langfuse_context.score_current_observation(
+    # ... LLM call and parsing ...
+    langfuse.score_current_span(
         name="output_count_valid",
-        value=1.0 if len(results) == len(batch) else 0.0,
+        value=1.0 if len(parsed) == len(batch) else 0.0,
+        comment=f"expected={len(batch)}, got={len(parsed)}",
     )
+```
+
+**Trace-level quality scoring** (after all batches complete):
+```python
+Langfuse().score_current_trace(
+    name="validation_pass_rate",
+    value=round(self.valid_count / total, 4),
+    comment=f"{self.__class__.__name__}: {self.valid_count}/{total} passed",
+)
 ```
 
 Keys stored in Secrets Manager (`/fpl-platform/dev/langfuse-public-key`, `/fpl-platform/dev/langfuse-secret-key`).
 
+> **Note:** This project uses Langfuse SDK v4, which replaced the v2/v3 `langfuse_context` / `langfuse.decorators` API with `Langfuse()` instance methods and the `propagate_attributes` context manager. If upgrading Langfuse, check the migration guide.
+
 **What we trace:**
-- **Per batch call:** enricher name, batch size, prompt version, input/output token counts, latency, model
-- **Per gameweek run:** session ID (`{season}-gw{gameweek}`), total calls, total cost, success/failure counts
-- **Quality scores:** output count validation (did the LLM return the right number of items?)
+- **Per batch call:** enricher name, batch size, prompt version, model, input/output token counts, latency (all via observation metadata)
+- **Per gameweek run:** session ID (`{season}-gw{gameweek}`) groups all traces for one pipeline run; enricher name and prompt version propagated to all child spans
+- **Quality scores:**
+  - `output_count_valid` (per batch, numeric 0.0–1.0): did the LLM return the expected number of items?
+  - `validation_pass_rate` (per enricher trace, numeric 0.0–1.0): what fraction of LLM outputs passed Pydantic model validation?
 
 ### How these work together
 Prompt version metadata flows into every Langfuse trace, enabling A/B comparison between prompt versions with concrete metrics (cost, latency, output quality scores). When we deploy v2, the Langfuse dashboard shows side-by-side performance against v1 without any custom analytics work. Cost attribution per enricher type is immediate — we can see that fixture outlook is ~94% of spend (see ADR-0004) and whether a prompt change shifts that.
@@ -109,3 +148,4 @@ Prompt version metadata flows into every Langfuse trace, enabling A/B comparison
 - Adds `langfuse` as a dependency (OpenTelemetry, protobuf transitive deps)
 - Two secrets to manage in Secrets Manager
 - If Langfuse's cloud service is down, tracing silently fails (by design — doesn't block the pipeline)
+- Langfuse SDK has breaking API changes between major versions (v2→v3→v4); code examples in this ADR target v4 (`propagate_attributes`, `Langfuse()` instance methods)

--- a/services/curate/src/fpl_curate/handlers/curate_all.py
+++ b/services/curate/src/fpl_curate/handlers/curate_all.py
@@ -4,7 +4,7 @@ import logging
 from typing import Any
 
 import pyarrow as pa
-from langfuse import observe
+from langfuse import observe, propagate_attributes
 
 from fpl_curate.config import get_curate_settings
 from fpl_curate.curators.fixture_ticker import build_fixture_ticker, build_team_map
@@ -229,8 +229,14 @@ async def main(
 def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
     """AWS Lambda entry point for data curation."""
     _init_langfuse()
-    return RunHandler(
-        main_func=main,
-        required_main_params=REQUIRED_PARAMS,
-        optional_main_params=OPTIONAL_PARAMS,
-    ).lambda_executor(lambda_event=event)
+    season = event.get("season", "unknown")
+    gameweek = event.get("gameweek", 0)
+    with propagate_attributes(
+        session_id=f"{season}-gw{gameweek}",
+        metadata={"pipeline": "curate"},
+    ):
+        return RunHandler(
+            main_func=main,
+            required_main_params=REQUIRED_PARAMS,
+            optional_main_params=OPTIONAL_PARAMS,
+        ).lambda_executor(lambda_event=event)

--- a/services/enrich/src/fpl_enrich/enrichers/base.py
+++ b/services/enrich/src/fpl_enrich/enrichers/base.py
@@ -9,7 +9,7 @@ from collections.abc import Iterator
 from typing import Any
 
 import anthropic
-from langfuse import observe
+from langfuse import Langfuse, observe
 
 logger = logging.getLogger(__name__)
 
@@ -124,6 +124,16 @@ class FPLEnricher(ABC):
                     self.invalid_count += 1
 
         self._log_summary()
+
+        # Score the parent trace with overall validation pass rate
+        total = self.valid_count + self.invalid_count
+        if total > 0:
+            Langfuse().score_current_trace(
+                name="validation_pass_rate",
+                value=round(self.valid_count / total, 4),
+                comment=f"{self.__class__.__name__}: {self.valid_count}/{total} passed",
+            )
+
         return results
 
     async def _call_llm_controlled(self, batch: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -145,6 +155,15 @@ class FPLEnricher(ABC):
     @observe(name="enricher_batch_call")
     async def _call_llm(self, batch: list[dict[str, Any]]) -> list[dict[str, Any]]:
         """Send a batch of items to the Anthropic API and parse the JSON response."""
+        langfuse = Langfuse()
+        langfuse.update_current_span(
+            metadata={
+                "enricher": self.__class__.__name__,
+                "prompt_version": self.prompt_version,
+                "model": self.MODEL,
+                "batch_size": len(batch),
+            },
+        )
         prepared = [self._prepare_item(item) for item in batch]
         user_content = "\n".join(f"I{i + 1}: {json.dumps(item)}" for i, item in enumerate(prepared))
 
@@ -203,7 +222,14 @@ class FPLEnricher(ABC):
             )
             raise
 
-        if len(parsed) != len(batch):
+        count_valid = len(parsed) == len(batch)
+        langfuse.score_current_span(
+            name="output_count_valid",
+            value=1.0 if count_valid else 0.0,
+            comment=f"expected={len(batch)}, got={len(parsed)}",
+        )
+
+        if not count_valid:
             raise ValueError(f"Output count mismatch: expected {len(batch)}, got {len(parsed)}")
 
         return parsed

--- a/services/enrich/src/fpl_enrich/handlers/enricher.py
+++ b/services/enrich/src/fpl_enrich/handlers/enricher.py
@@ -7,7 +7,7 @@ from typing import Any
 import anthropic
 import boto3
 import pyarrow as pa
-from langfuse import observe
+from langfuse import observe, propagate_attributes
 
 from fpl_enrich.enrichers.base import RateLimiter
 from fpl_enrich.enrichers.fixture_outlook import FixtureOutlookEnricher
@@ -233,8 +233,14 @@ async def main(
 def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
     """AWS Lambda entry point for enrichment."""
     _init_langfuse()
-    return RunHandler(
-        main_func=main,
-        required_main_params=["season", "gameweek"],
-        optional_main_params=["output_bucket", "cost_bucket", "prompt_version"],
-    ).lambda_executor(lambda_event=event)
+    season = event.get("season", "unknown")
+    gameweek = event.get("gameweek", 0)
+    with propagate_attributes(
+        session_id=f"{season}-gw{gameweek}",
+        metadata={"prompt_version": event.get("prompt_version", "v1"), "pipeline": "enrich_all"},
+    ):
+        return RunHandler(
+            main_func=main,
+            required_main_params=["season", "gameweek"],
+            optional_main_params=["output_bucket", "cost_bucket", "prompt_version"],
+        ).lambda_executor(lambda_event=event)

--- a/services/enrich/src/fpl_enrich/handlers/single_enricher.py
+++ b/services/enrich/src/fpl_enrich/handlers/single_enricher.py
@@ -12,7 +12,7 @@ from typing import Any
 
 import anthropic
 import boto3
-from langfuse import observe
+from langfuse import observe, propagate_attributes
 
 from fpl_enrich.enrichers.base import RateLimiter
 from fpl_enrich.enrichers.fixture_outlook import FixtureOutlookEnricher
@@ -373,38 +373,68 @@ async def fixture_outlook_main(
 def player_summary_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
     """Lambda entry point for player summary enrichment."""
     _init_langfuse()
-    return RunHandler(
-        main_func=player_summary_main,
-        required_main_params=["season", "gameweek"],
-        optional_main_params=["output_bucket", "prompt_version"],
-    ).lambda_executor(lambda_event=event)
+    season = event.get("season", "unknown")
+    gameweek = event.get("gameweek", 0)
+    with propagate_attributes(
+        session_id=f"{season}-gw{gameweek}",
+        metadata={
+            "enricher": "player_summary",
+            "prompt_version": event.get("prompt_version", "v1"),
+        },
+    ):
+        return RunHandler(
+            main_func=player_summary_main,
+            required_main_params=["season", "gameweek"],
+            optional_main_params=["output_bucket", "prompt_version"],
+        ).lambda_executor(lambda_event=event)
 
 
 def injury_signal_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
     """Lambda entry point for injury signal enrichment."""
     _init_langfuse()
-    return RunHandler(
-        main_func=injury_signal_main,
-        required_main_params=["season", "gameweek"],
-        optional_main_params=["output_bucket", "prompt_version"],
-    ).lambda_executor(lambda_event=event)
+    season = event.get("season", "unknown")
+    gameweek = event.get("gameweek", 0)
+    with propagate_attributes(
+        session_id=f"{season}-gw{gameweek}",
+        metadata={"enricher": "injury_signal", "prompt_version": event.get("prompt_version", "v1")},
+    ):
+        return RunHandler(
+            main_func=injury_signal_main,
+            required_main_params=["season", "gameweek"],
+            optional_main_params=["output_bucket", "prompt_version"],
+        ).lambda_executor(lambda_event=event)
 
 
 def sentiment_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
     """Lambda entry point for sentiment enrichment."""
     _init_langfuse()
-    return RunHandler(
-        main_func=sentiment_main,
-        required_main_params=["season", "gameweek"],
-        optional_main_params=["output_bucket", "prompt_version"],
-    ).lambda_executor(lambda_event=event)
+    season = event.get("season", "unknown")
+    gameweek = event.get("gameweek", 0)
+    with propagate_attributes(
+        session_id=f"{season}-gw{gameweek}",
+        metadata={"enricher": "sentiment", "prompt_version": event.get("prompt_version", "v1")},
+    ):
+        return RunHandler(
+            main_func=sentiment_main,
+            required_main_params=["season", "gameweek"],
+            optional_main_params=["output_bucket", "prompt_version"],
+        ).lambda_executor(lambda_event=event)
 
 
 def fixture_outlook_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
     """Lambda entry point for fixture outlook enrichment."""
     _init_langfuse()
-    return RunHandler(
-        main_func=fixture_outlook_main,
-        required_main_params=["season", "gameweek"],
-        optional_main_params=["output_bucket", "prompt_version"],
-    ).lambda_executor(lambda_event=event)
+    season = event.get("season", "unknown")
+    gameweek = event.get("gameweek", 0)
+    with propagate_attributes(
+        session_id=f"{season}-gw{gameweek}",
+        metadata={
+            "enricher": "fixture_outlook",
+            "prompt_version": event.get("prompt_version", "v1"),
+        },
+    ):
+        return RunHandler(
+            main_func=fixture_outlook_main,
+            required_main_params=["season", "gameweek"],
+            optional_main_params=["output_bucket", "prompt_version"],
+        ).lambda_executor(lambda_event=event)


### PR DESCRIPTION
## Summary
- Wires up Langfuse observability levels 2 (sessions + metadata) and 3 (quality scores) as described in ADR-0005
- All enrichment and curation traces now carry `session_id` (`{season}-gw{gameweek}`) via `propagate_attributes`, enabling gameweek-level grouping in the Langfuse Sessions view
- Each `enricher_batch_call` observation includes metadata: enricher name, prompt version, model, batch size — enabling filtering and A/B comparison between prompt versions
- Two quality scores track LLM output reliability:
  - `output_count_valid` (per batch call): 1.0 if LLM returned the expected item count, 0.0 otherwise
  - `validation_pass_rate` (per enricher trace): fraction of items that passed Pydantic validation

## Files changed
- `services/enrich/src/fpl_enrich/enrichers/base.py` — metadata + scores on batch calls and enricher runs
- `services/enrich/src/fpl_enrich/handlers/enricher.py` — session ID on batch enrichment handler
- `services/enrich/src/fpl_enrich/handlers/single_enricher.py` — session ID + enricher metadata on all 4 individual handlers
- `services/curate/src/fpl_curate/handlers/curate_all.py` — session ID on curation handler
- `CHANGELOG.md` — documented additions

## Test plan
- [x] `ruff check .` passes
- [x] `ruff format --check .` passes
- [x] `pytest tests/ -x -q` — 22 tests pass
- [ ] Deploy to dev and trigger a gameweek enrichment run
- [ ] Verify in Langfuse: traces grouped under session `2025-26-gw{N}`
- [ ] Verify in Langfuse: batch observations show enricher/model/prompt_version metadata
- [ ] Verify in Langfuse: Scores tab shows `output_count_valid` and `validation_pass_rate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)