### PR TITLE
fix(data): add statusCode guard and 403 retry to gameweek resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Step Function: Added `CheckResolveStatus` guard before `CheckShouldRun` — prevents execution crash when `ResolveGameweek` Lambda returns a non-200 status (e.g. Cloudflare 403)
+- Gameweek resolver: Added 403 retry with exponential backoff (matching `fpl_api_collector` pattern) — single-attempt fetch was failing on intermittent Cloudflare challenges
+
 ### Added
 - Langfuse session IDs (`{season}-gw{gameweek}`) on all enrichment and curation traces — enables grouping all traces for a gameweek run in a single Langfuse session view
 - Langfuse metadata (enricher name, prompt version, model, batch size) on every `enricher_batch_call` observation — enables filtering and comparing traces by enricher or prompt version

--- a/infrastructure/step_function_definitions/fpl-collection-pipeline.json.tpl
+++ b/infrastructure/step_function_definitions/fpl-collection-pipeline.json.tpl
@@ -38,7 +38,19 @@
           "Next": "PipelineFailed"
         }
       ],
-      "Next": "CheckShouldRun"
+      "Next": "CheckResolveStatus"
+    },
+    "CheckResolveStatus": {
+      "Type": "Choice",
+      "Comment": "Guard: route to PipelineFailed if the resolve Lambda returned a non-200 status",
+      "Choices": [
+        {
+          "Variable": "$.resolved.statusCode",
+          "NumericEquals": 200,
+          "Next": "CheckShouldRun"
+        }
+      ],
+      "Default": "PipelineFailed"
     },
     "CheckShouldRun": {
       "Type": "Choice",

--- a/services/data/src/fpl_data/collectors/gameweek_resolver.py
+++ b/services/data/src/fpl_data/collectors/gameweek_resolver.py
@@ -7,6 +7,7 @@ Uses curl_cffi to impersonate Chrome's TLS fingerprint, which prevents
 Cloudflare from blocking requests originating from AWS Lambda IPs.
 """
 
+import asyncio
 import logging
 
 from curl_cffi.requests import AsyncSession
@@ -14,6 +15,7 @@ from curl_cffi.requests import AsyncSession
 logger = logging.getLogger(__name__)
 
 FPL_BOOTSTRAP_URL = "https://fantasy.premierleague.com/api/bootstrap-static/"
+MAX_RETRIES = 5
 
 
 class GameweekInfo:
@@ -46,8 +48,25 @@ async def resolve_gameweek(season: str = "2025-26") -> GameweekInfo:
         ValueError: If no gameweek data is found in the API response.
     """
     async with AsyncSession(impersonate="chrome", timeout=30) as session:
-        response = await session.get(FPL_BOOTSTRAP_URL)
-        response.raise_for_status()
+        for attempt in range(MAX_RETRIES):
+            response = await session.get(FPL_BOOTSTRAP_URL)
+
+            if response.status_code == 200:
+                break
+
+            if response.status_code == 403 and attempt < MAX_RETRIES - 1:
+                wait = 2 ** (attempt + 1)  # 2, 4, 8, 16, 32 seconds
+                logger.warning(
+                    "[FPL API] 403 Forbidden — retrying in %ds (attempt %d/%d)",
+                    wait,
+                    attempt + 1,
+                    MAX_RETRIES,
+                )
+                await asyncio.sleep(wait)
+                continue
+
+            response.raise_for_status()
+
         data = response.json()
 
     events = data.get("events", [])


### PR DESCRIPTION
## Summary
- **Step Function guard**: Added `CheckResolveStatus` Choice state before `CheckShouldRun` that validates `$.resolved.statusCode == 200` before reading `should_run` from the body — non-200 responses now route to `PipelineFailed` instead of crashing the execution
- **Gameweek resolver retry**: Added exponential backoff retry on Cloudflare 403s (5 attempts, 2/4/8/16/32s waits) matching the existing pattern in `fpl_api_collector._fetch()` — the resolver was the only FPL API caller without retry logic

### Root cause
The weekly scheduled execution (Apr 7) failed because Cloudflare returned a 403 on the first FPL API request. `RunHandler` caught the exception and returned `{"statusCode": 500, "body": {"error": "HTTP Error 403"}}`. Step Functions saw this as a successful Lambda invocation (not a `States.TaskFailed`), so the Catch block didn't trigger. `CheckShouldRun` then tried to evaluate `$.resolved.body.should_run` on a payload that only had `$.resolved.body.error`.

## Test plan
- [x] `ruff check .` — all checks passed
- [x] `pytest tests/` — 22 passed
- [ ] Verify Step Function definition renders correctly after `terraform plan`
- [ ] Trigger a test execution with `force: true` to confirm end-to-end flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)