### PR TITLE
feat(infra): add SNS email notifications for pipeline execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Gameweek resolver: Added 403 retry with exponential backoff (matching `fpl_api_collector` pattern) — single-attempt fetch was failing on intermittent Cloudflare challenges
 
 ### Added
+- Pipeline email notifications via EventBridge → SNS — sends email on pipeline success, failure, timeout, or abort
 - Langfuse session IDs (`{season}-gw{gameweek}`) on all enrichment and curation traces — enables grouping all traces for a gameweek run in a single Langfuse session view
 - Langfuse metadata (enricher name, prompt version, model, batch size) on every `enricher_batch_call` observation — enables filtering and comparing traces by enricher or prompt version
 - Langfuse `output_count_valid` score on each LLM batch call — flags when the model returns fewer items than requested

--- a/infrastructure/environments/dev/main.tf
+++ b/infrastructure/environments/dev/main.tf
@@ -85,6 +85,54 @@ resource "aws_sns_topic_subscription" "email_alert" {
   endpoint  = var.notification_email
 }
 
+resource "aws_sns_topic_policy" "pipeline_alerts" {
+  arn = aws_sns_topic.pipeline_alerts.arn
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "AllowEventBridgePublish"
+        Effect    = "Allow"
+        Principal = { Service = "events.amazonaws.com" }
+        Action    = "sns:Publish"
+        Resource  = aws_sns_topic.pipeline_alerts.arn
+      }
+    ]
+  })
+}
+
+# EventBridge rule: notify on pipeline success or failure
+resource "aws_cloudwatch_event_rule" "pipeline_notify" {
+  name        = "fpl-pipeline-notify-${var.environment}"
+  description = "Fires when the FPL pipeline succeeds, fails, times out, or is aborted"
+
+  event_pattern = jsonencode({
+    source      = ["aws.states"]
+    detail-type = ["Step Functions Execution Status Change"]
+    detail = {
+      status          = ["SUCCEEDED", "FAILED", "TIMED_OUT", "ABORTED"]
+      stateMachineArn = [module.pipeline.state_machine_arn]
+    }
+  })
+}
+
+resource "aws_cloudwatch_event_target" "pipeline_notify_sns" {
+  rule      = aws_cloudwatch_event_rule.pipeline_notify.name
+  target_id = "pipeline-sns-notify"
+  arn       = aws_sns_topic.pipeline_alerts.arn
+
+  input_transformer {
+    input_paths = {
+      status = "$.detail.status"
+      name   = "$.detail.name"
+      time   = "$.time"
+      arn    = "$.detail.executionArn"
+    }
+    input_template = "\"FPL Pipeline — <status>\\n\\nExecution: <name>\\nTime: <time>\\nARN: <arn>\\n\\nCheck the Step Functions console for full execution details.\""
+  }
+}
+
 # -----------------------------------------------------------------------------
 # Secrets Manager
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Wires the existing (unused) `pipeline_alerts` SNS topic to EventBridge so pipeline completion events trigger an email notification
- Covers all terminal states: SUCCEEDED, FAILED, TIMED_OUT, ABORTED
- Adds SNS topic policy granting EventBridge publish permission
- Uses input transformer to format a readable message with status, execution name, timestamp, and ARN

Partially addresses #30 (CloudWatch + Step Functions observability).

## Test plan
- [ ] `terraform plan` shows 3 new resources (event rule, target, topic policy)
- [ ] `terraform apply` succeeds
- [ ] Confirm SNS email subscription (check inbox for AWS confirmation link if not already confirmed)
- [ ] Trigger a pipeline run and verify email arrives on success
- [ ] Force a failure and verify email arrives on failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)