### PR TITLE
fix(infra): comment out bootstrap remote state until migration

### DIFF
--- a/infrastructure/environments/dev/main.tf
+++ b/infrastructure/environments/dev/main.tf
@@ -19,7 +19,7 @@ provider "aws" {
 # -----------------------------------------------------------------------------
 # Remote state — bootstrap stack (OIDC provider, CICD role, budget alerts)
 #
-# Prerequisite: migrate bootstrap local state to S3:
+# TODO: Uncomment after migrating bootstrap local state to S3:
 #   cd infrastructure/bootstrap
 #   terraform init -migrate-state \
 #     -backend-config="bucket=fpl-dev-tf-state" \
@@ -28,15 +28,15 @@ provider "aws" {
 #     -backend-config="dynamodb_table=fpl-dev-tf-lock-table" \
 #     -backend-config="encrypt=true"
 # -----------------------------------------------------------------------------
-data "terraform_remote_state" "bootstrap" {
-  backend = "s3"
-
-  config = {
-    bucket = "fpl-dev-tf-state"
-    key    = "bootstrap/terraform.tfstate"
-    region = "eu-west-2"
-  }
-}
+# data "terraform_remote_state" "bootstrap" {
+#   backend = "s3"
+#
+#   config = {
+#     bucket = "fpl-dev-tf-state"
+#     key    = "bootstrap/terraform.tfstate"
+#     region = "eu-west-2"
+#   }
+# }
 
 # -----------------------------------------------------------------------------
 # S3 Data Lake


### PR DESCRIPTION
## Summary
- Comments out `terraform_remote_state.bootstrap` data source that blocks `terraform plan/apply` — bootstrap state has not been migrated to S3 yet

Fixes the CI failure from #104.

## Test plan
- [ ] `terraform plan` in `environments/dev/` succeeds without remote state error

🤖 Generated with [Claude Code](https://claude.com/claude-code)