### PR TITLE
fix(infra): remove dead terraform_remote_state block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Infra: `modules/lambda-role/` — reusable IAM execution role module for pipeline Lambdas (S3, Secrets Manager, CloudWatch Logs, SNS policies)
-- Infra: `terraform_remote_state` data source for bootstrap stack in dev environment (requires bootstrap state migration to S3 — see comment in main.tf)
 - Infra: Comment on Secrets Manager resources documenting manual console population workflow
 - `.gitignore`: Stopped ignoring `.terraform.lock.hcl` — lock files should be committed to pin provider versions
 

--- a/infrastructure/environments/dev/main.tf
+++ b/infrastructure/environments/dev/main.tf
@@ -17,28 +17,6 @@ provider "aws" {
 }
 
 # -----------------------------------------------------------------------------
-# Remote state — bootstrap stack (OIDC provider, CICD role, budget alerts)
-#
-# TODO: Uncomment after migrating bootstrap local state to S3:
-#   cd infrastructure/bootstrap
-#   terraform init -migrate-state \
-#     -backend-config="bucket=fpl-dev-tf-state" \
-#     -backend-config="key=bootstrap/terraform.tfstate" \
-#     -backend-config="region=eu-west-2" \
-#     -backend-config="dynamodb_table=fpl-dev-tf-lock-table" \
-#     -backend-config="encrypt=true"
-# -----------------------------------------------------------------------------
-# data "terraform_remote_state" "bootstrap" {
-#   backend = "s3"
-#
-#   config = {
-#     bucket = "fpl-dev-tf-state"
-#     key    = "bootstrap/terraform.tfstate"
-#     region = "eu-west-2"
-#   }
-# }
-
-# -----------------------------------------------------------------------------
 # S3 Data Lake
 # -----------------------------------------------------------------------------
 module "data_lake" {


### PR DESCRIPTION
## Summary
- Removes the commented-out `terraform_remote_state.bootstrap` data source from `environments/dev/main.tf` — it had no consumers (backend config must be static, CICD role is only used in GitHub Actions)
- Removes the corresponding CHANGELOG entry

Cleans up dead code introduced in #104 and patched in #106.

## Test plan
- [ ] `terraform plan` in `environments/dev/` — clean plan, no changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)