### PR TITLE
feat(agent): add Neon pgvector client and embedding pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Data: `TeamFetcher` class for fetching FPL manager squads with Chrome TLS impersonation (curl_cffi)
 - Data: Lambda handler for team fetching, invokable by the agent service via boto3
 - Data: Custom exceptions `TeamNotFoundError` and `FPLAccessError` for FPL API error handling
+- Agent: `NeonClient` async Postgres wrapper in shared lib (`fpl_lib.clients.neon`) for Neon pgvector operations
+- Agent: `PlayerEmbedder` class using sentence-transformers all-MiniLM-L6-v2 for 384-dim player profile embeddings
+- Agent: `sync_embeddings` function to read curated S3 data, generate embeddings, and upsert into Neon pgvector
+- Agent: Lambda handler (`sync_handler`) for triggering embedding sync via Step Functions
+- Agent: `player_embeddings` schema with IVFFlat vector index and structured filtering indexes
 
 ### Changed
 - Data: Extract shared `fpl_fetch` function into `collectors/http.py` — single FPL API fetch implementation with Cloudflare bypass used by all collectors

--- a/libs/fpl_lib/clients/__init__.py
+++ b/libs/fpl_lib/clients/__init__.py
@@ -1,1 +1,6 @@
 """Client wrappers for external services."""
+
+from fpl_lib.clients.neon import NeonClient
+from fpl_lib.clients.s3 import S3Client
+
+__all__ = ["NeonClient", "S3Client"]

--- a/libs/fpl_lib/clients/neon.py
+++ b/libs/fpl_lib/clients/neon.py
@@ -1,0 +1,62 @@
+"""Async Postgres client wrapper for Neon with pgvector support.
+
+Uses asyncpg for async connections. Connection string sourced from
+Secrets Manager or environment variable NEON_DATABASE_URL.
+"""
+
+import logging
+from typing import Any
+
+import asyncpg
+
+logger = logging.getLogger(__name__)
+
+
+class NeonClient:
+    """Async wrapper around asyncpg for Neon Postgres operations."""
+
+    def __init__(self, database_url: str) -> None:
+        self._database_url = database_url
+        self._conn: asyncpg.Connection | None = None
+
+    async def connect(self) -> None:
+        """Establish connection to Neon Postgres."""
+        self._conn = await asyncpg.connect(self._database_url)
+        logger.info("Connected to Neon Postgres")
+
+    async def close(self) -> None:
+        """Close the database connection."""
+        if self._conn:
+            await self._conn.close()
+            self._conn = None
+            logger.info("Closed Neon Postgres connection")
+
+    async def execute(self, query: str, *args: Any) -> str:
+        """Execute a query and return the status string."""
+        self._ensure_connected()
+        result: str = await self._conn.execute(query, *args)  # type: ignore[union-attr]
+        return result
+
+    async def fetch(self, query: str, *args: Any) -> list[asyncpg.Record]:
+        """Execute a query and return all rows."""
+        self._ensure_connected()
+        return await self._conn.fetch(query, *args)  # type: ignore[union-attr]
+
+    async def fetch_one(self, query: str, *args: Any) -> asyncpg.Record | None:
+        """Execute a query and return a single row, or None."""
+        self._ensure_connected()
+        return await self._conn.fetchrow(query, *args)  # type: ignore[union-attr]
+
+    def _ensure_connected(self) -> None:
+        """Raise if the client has not been connected."""
+        if self._conn is None:
+            raise RuntimeError(
+                "NeonClient is not connected. Call connect() or use as async context manager."
+            )
+
+    async def __aenter__(self) -> "NeonClient":
+        await self.connect()
+        return self
+
+    async def __aexit__(self, exc_type: type | None, exc_val: Exception | None, exc_tb: Any) -> None:
+        await self.close()

--- a/libs/fpl_lib/clients/neon.py
+++ b/libs/fpl_lib/clients/neon.py
@@ -58,5 +58,7 @@ class NeonClient:
         await self.connect()
         return self
 
-    async def __aexit__(self, exc_type: type | None, exc_val: Exception | None, exc_tb: Any) -> None:
+    async def __aexit__(
+        self, exc_type: type | None, exc_val: Exception | None, exc_tb: Any
+    ) -> None:
         await self.close()

--- a/libs/pyproject.toml
+++ b/libs/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "pydantic>=2.0.0",
     "pydantic-settings>=2.0.0",
     "pyarrow>=14.0.0",
+    "asyncpg>=0.29.0",
 ]
 
 [project.optional-dependencies]

--- a/services/agent/pyproject.toml
+++ b/services/agent/pyproject.toml
@@ -14,6 +14,9 @@ dependencies = [
     "langfuse>=2.0.0",
     "fastapi>=0.110.0",
     "mangum>=0.17.0",
+    "sentence-transformers>=2.0.0",
+    "asyncpg>=0.29.0",
+    "pgvector>=0.2.0",
 ]
 
 [project.optional-dependencies]

--- a/services/agent/src/fpl_agent/embeddings/__init__.py
+++ b/services/agent/src/fpl_agent/embeddings/__init__.py
@@ -1,0 +1,1 @@
+"""Embedding generation and vector storage for player profiles."""

--- a/services/agent/src/fpl_agent/embeddings/embedder.py
+++ b/services/agent/src/fpl_agent/embeddings/embedder.py
@@ -1,0 +1,73 @@
+"""Embed player profiles using sentence-transformers all-MiniLM-L6-v2.
+
+Runs locally on CPU — no API key needed. ~500 players takes <5 seconds.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from sentence_transformers import SentenceTransformer
+
+logger = logging.getLogger(__name__)
+
+
+class PlayerEmbedder:
+    """Generates 384-dim embeddings for player profiles."""
+
+    MODEL_NAME = "all-MiniLM-L6-v2"
+    EMBEDDING_DIM = 384
+
+    def __init__(self) -> None:
+        self._model: SentenceTransformer | None = None
+
+    def _get_model(self) -> SentenceTransformer:
+        """Lazy-load the sentence-transformer model on first use."""
+        if self._model is None:
+            logger.info("Loading sentence-transformer model: %s", self.MODEL_NAME)
+            self._model = SentenceTransformer(self.MODEL_NAME)
+        return self._model
+
+    def embed_text(self, text: str) -> list[float]:
+        """Embed a single text string into a 384-dim vector."""
+        embedding: list[float] = self._get_model().encode(text).tolist()
+        return embedding
+
+    def embed_batch(self, texts: list[str]) -> list[list[float]]:
+        """Embed a batch of texts into 384-dim vectors."""
+        if not texts:
+            return []
+        embeddings: list[list[float]] = self._get_model().encode(texts).tolist()
+        return embeddings
+
+    @staticmethod
+    def build_profile_text(player: dict[str, Any]) -> str:
+        """Combine player stats and enrichments into a single text for embedding.
+
+        Args:
+            player: Dict of player data from the curated player_dashboard layer.
+
+        Returns:
+            Natural language profile string suitable for embedding.
+        """
+        web_name = player.get("web_name", "Unknown")
+        position = player.get("position", "N/A")
+        team_name = player.get("team_name", "N/A")
+        price = player.get("price", "N/A")
+        form = player.get("form", "N/A")
+        total_points = player.get("total_points", "N/A")
+        goals_scored = player.get("goals_scored", "N/A")
+        assists = player.get("assists", "N/A")
+        llm_summary = player.get("llm_summary") or "No summary available"
+        form_trend = player.get("form_trend") or "N/A"
+        injury_risk = player.get("injury_risk") if player.get("injury_risk") is not None else "N/A"
+        fdr_next_3 = player.get("fdr_next_3") if player.get("fdr_next_3") is not None else "N/A"
+
+        return (
+            f"{web_name} ({position}, {team_name}). Price: £{price}m. Form: {form}.\n"
+            f"Points: {total_points}. Goals: {goals_scored}, Assists: {assists}.\n"
+            f"Summary: {llm_summary}\n"
+            f"Form trend: {form_trend}. Injury risk: {injury_risk}/10.\n"
+            f"Fixture difficulty (next 3): {fdr_next_3}/5."
+        )

--- a/services/agent/src/fpl_agent/embeddings/schema.sql
+++ b/services/agent/src/fpl_agent/embeddings/schema.sql
@@ -1,0 +1,36 @@
+-- Player embeddings schema for Neon pgvector.
+-- Apply manually to a fresh Neon database before running the sync handler.
+
+CREATE EXTENSION IF NOT EXISTS vector;
+
+CREATE TABLE IF NOT EXISTS player_embeddings (
+    player_id          INTEGER PRIMARY KEY,
+    season             VARCHAR(10) NOT NULL,
+    gameweek           INTEGER NOT NULL,
+    web_name           VARCHAR(100) NOT NULL,
+    team_name          VARCHAR(100) NOT NULL,
+    position           VARCHAR(3) NOT NULL,
+    price              REAL NOT NULL,
+    total_points       INTEGER NOT NULL,
+    form               REAL NOT NULL,
+    goals_scored       INTEGER NOT NULL,
+    assists            INTEGER NOT NULL,
+    minutes            INTEGER NOT NULL,
+    summary            TEXT,
+    form_trend         VARCHAR(20),
+    injury_risk_score  INTEGER,
+    fixture_difficulty REAL,
+    embedding          vector(384) NOT NULL,
+    updated_at         TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- IVFFlat index for approximate nearest-neighbour vector search.
+-- lists = ~sqrt(expected_rows) ≈ sqrt(300) ≈ 20.
+CREATE INDEX IF NOT EXISTS idx_player_embeddings_vector
+    ON player_embeddings USING ivfflat (embedding vector_cosine_ops)
+    WITH (lists = 20);
+
+-- Filtering indexes for structured queries.
+CREATE INDEX IF NOT EXISTS idx_player_embeddings_position ON player_embeddings (position);
+CREATE INDEX IF NOT EXISTS idx_player_embeddings_team ON player_embeddings (team_name);
+CREATE INDEX IF NOT EXISTS idx_player_embeddings_price ON player_embeddings (price);

--- a/services/agent/src/fpl_agent/embeddings/sync_embeddings.py
+++ b/services/agent/src/fpl_agent/embeddings/sync_embeddings.py
@@ -1,0 +1,118 @@
+"""Sync curated player data + enrichments into Neon pgvector.
+
+Reads from S3 curated layer, generates embeddings, upserts into Neon.
+Designed to run after each pipeline execution (triggered by Step Functions).
+"""
+
+import logging
+import time
+from typing import Any
+
+from fpl_agent.embeddings.embedder import PlayerEmbedder
+from fpl_lib.clients.neon import NeonClient
+from fpl_lib.clients.s3 import S3Client
+
+logger = logging.getLogger(__name__)
+
+UPSERT_QUERY = """
+INSERT INTO player_embeddings (
+    player_id, season, gameweek, web_name, team_name, position,
+    price, total_points, form, goals_scored, assists, minutes,
+    summary, form_trend, injury_risk_score, fixture_difficulty,
+    embedding, updated_at
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, NOW())
+ON CONFLICT (player_id) DO UPDATE SET
+    season = EXCLUDED.season,
+    gameweek = EXCLUDED.gameweek,
+    web_name = EXCLUDED.web_name,
+    team_name = EXCLUDED.team_name,
+    position = EXCLUDED.position,
+    price = EXCLUDED.price,
+    total_points = EXCLUDED.total_points,
+    form = EXCLUDED.form,
+    goals_scored = EXCLUDED.goals_scored,
+    assists = EXCLUDED.assists,
+    minutes = EXCLUDED.minutes,
+    summary = EXCLUDED.summary,
+    form_trend = EXCLUDED.form_trend,
+    injury_risk_score = EXCLUDED.injury_risk_score,
+    fixture_difficulty = EXCLUDED.fixture_difficulty,
+    embedding = EXCLUDED.embedding,
+    updated_at = NOW()
+"""
+
+
+async def sync_embeddings(
+    s3_client: S3Client,
+    neon_client: NeonClient,
+    embedder: PlayerEmbedder,
+    bucket: str,
+    season: str,
+    gameweek: int,
+) -> dict[str, Any]:
+    """Read curated player data from S3, embed, and upsert into Neon.
+
+    Args:
+        s3_client: S3 client for reading curated data.
+        neon_client: Connected Neon client for upserting embeddings.
+        embedder: PlayerEmbedder instance for generating vectors.
+        bucket: S3 bucket containing the curated data lake.
+        season: Season string, e.g. "2025-26".
+        gameweek: Gameweek number.
+
+    Returns:
+        Dict with players_synced, embedding_dim, and duration_seconds.
+    """
+    start = time.time()
+
+    key = (
+        f"curated/player_dashboard/season={season}"
+        f"/gameweek={gameweek:02d}/player_dashboard.parquet"
+    )
+    logger.info("Reading curated data from s3://%s/%s", bucket, key)
+    table = s3_client.read_parquet(bucket, key)
+    players = table.to_pylist()
+
+    if not players:
+        logger.warning("No players found in curated data for %s GW%d", season, gameweek)
+        return {"players_synced": 0, "embedding_dim": PlayerEmbedder.EMBEDDING_DIM, "duration_seconds": 0.0}
+
+    logger.info("Building profile texts for %d players", len(players))
+    texts = [embedder.build_profile_text(p) for p in players]
+
+    logger.info("Generating embeddings for %d players", len(players))
+    embeddings = embedder.embed_batch(texts)
+
+    logger.info("Upserting %d players into Neon", len(players))
+    synced = 0
+    for player, embedding in zip(players, embeddings, strict=True):
+        await neon_client.execute(
+            UPSERT_QUERY,
+            player.get("player_id", 0),
+            season,
+            gameweek,
+            player.get("web_name", "Unknown"),
+            player.get("team_name", "Unknown"),
+            player.get("position", "N/A"),
+            float(player.get("price", 0.0)),
+            int(player.get("total_points", 0)),
+            float(player.get("form", 0.0)),
+            int(player.get("goals_scored", 0)),
+            int(player.get("assists", 0)),
+            int(player.get("minutes", 0)),
+            player.get("llm_summary"),
+            player.get("form_trend"),
+            int(player["injury_risk"]) if player.get("injury_risk") is not None else None,
+            float(player["fdr_next_3"]) if player.get("fdr_next_3") is not None else None,
+            embedding,
+        )
+        synced += 1
+
+    duration = round(time.time() - start, 2)
+    logger.info("Synced %d players in %.2fs", synced, duration)
+
+    return {
+        "players_synced": synced,
+        "embedding_dim": PlayerEmbedder.EMBEDDING_DIM,
+        "duration_seconds": duration,
+    }

--- a/services/agent/src/fpl_agent/embeddings/sync_embeddings.py
+++ b/services/agent/src/fpl_agent/embeddings/sync_embeddings.py
@@ -66,8 +66,7 @@ async def sync_embeddings(
     start = time.time()
 
     key = (
-        f"curated/player_dashboard/season={season}"
-        f"/gameweek={gameweek:02d}/player_dashboard.parquet"
+        f"curated/player_dashboard/season={season}/gameweek={gameweek:02d}/player_dashboard.parquet"
     )
     logger.info("Reading curated data from s3://%s/%s", bucket, key)
     table = s3_client.read_parquet(bucket, key)
@@ -75,7 +74,11 @@ async def sync_embeddings(
 
     if not players:
         logger.warning("No players found in curated data for %s GW%d", season, gameweek)
-        return {"players_synced": 0, "embedding_dim": PlayerEmbedder.EMBEDDING_DIM, "duration_seconds": 0.0}
+        return {
+            "players_synced": 0,
+            "embedding_dim": PlayerEmbedder.EMBEDDING_DIM,
+            "duration_seconds": 0.0,
+        }
 
     logger.info("Building profile texts for %d players", len(players))
     texts = [embedder.build_profile_text(p) for p in players]

--- a/services/agent/src/fpl_agent/handlers/__init__.py
+++ b/services/agent/src/fpl_agent/handlers/__init__.py
@@ -1,0 +1,1 @@
+"""Lambda handler entry points for the agent service."""

--- a/services/agent/src/fpl_agent/handlers/sync_handler.py
+++ b/services/agent/src/fpl_agent/handlers/sync_handler.py
@@ -1,0 +1,74 @@
+"""Lambda handler for syncing player embeddings into Neon pgvector.
+
+Reads curated player data from S3, generates embeddings, and upserts
+into the Neon vector database. Triggered by Step Functions after
+the curate stage completes.
+"""
+
+import logging
+from typing import Any
+
+import boto3
+from pgvector.asyncpg import register_vector
+
+from fpl_agent.embeddings.embedder import PlayerEmbedder
+from fpl_agent.embeddings.sync_embeddings import sync_embeddings
+from fpl_lib.clients.neon import NeonClient
+from fpl_lib.clients.s3 import S3Client
+from fpl_lib.core.run_handler import RunHandler
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_BUCKET = "fpl-data-lake-dev"
+NEON_SECRET_ID = "/fpl-platform/dev/neon-database-url"
+
+
+def _get_neon_database_url() -> str:
+    """Retrieve the Neon database URL from Secrets Manager."""
+    sm = boto3.client("secretsmanager", region_name="eu-west-2")
+    resp = sm.get_secret_value(SecretId=NEON_SECRET_ID)
+    return resp["SecretString"]
+
+
+async def main(
+    season: str,
+    gameweek: int,
+    output_bucket: str = DEFAULT_BUCKET,
+    force: bool = False,
+) -> dict[str, Any]:
+    """Sync player embeddings from curated S3 data into Neon pgvector.
+
+    Args:
+        season: Season string, e.g. "2025-26".
+        gameweek: Gameweek number.
+        output_bucket: S3 bucket containing curated data.
+        force: Not currently used; reserved for future skip-if-exists logic.
+
+    Returns:
+        Dict with players_synced, embedding_dim, and duration_seconds.
+    """
+    database_url = _get_neon_database_url()
+    s3_client = S3Client()
+    embedder = PlayerEmbedder()
+
+    async with NeonClient(database_url) as neon_client:
+        await register_vector(neon_client._conn)
+        result = await sync_embeddings(
+            s3_client=s3_client,
+            neon_client=neon_client,
+            embedder=embedder,
+            bucket=output_bucket,
+            season=season,
+            gameweek=gameweek,
+        )
+
+    return result
+
+
+def lambda_handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
+    """AWS Lambda entry point for embedding sync."""
+    return RunHandler(
+        main_func=main,
+        required_main_params=["season", "gameweek"],
+        optional_main_params=["output_bucket", "force"],
+    ).lambda_executor(lambda_event=event)

--- a/services/agent/tests/test_embedder.py
+++ b/services/agent/tests/test_embedder.py
@@ -1,0 +1,114 @@
+"""Tests for PlayerEmbedder."""
+
+import pytest
+
+from fpl_agent.embeddings.embedder import PlayerEmbedder
+
+
+@pytest.fixture(scope="module")
+def embedder() -> PlayerEmbedder:
+    """Load the sentence-transformer model once for all tests in this module."""
+    emb = PlayerEmbedder()
+    # Force model load so timing is in fixture, not first test.
+    emb._get_model()
+    return emb
+
+
+def _complete_player() -> dict:
+    """Return a player dict with all fields populated."""
+    return {
+        "player_id": 1,
+        "web_name": "Salah",
+        "position": "MID",
+        "team_name": "Liverpool",
+        "price": 13.0,
+        "form": 8.2,
+        "total_points": 180,
+        "goals_scored": 15,
+        "assists": 10,
+        "minutes": 2400,
+        "llm_summary": "Consistent performer with excellent goal output.",
+        "form_trend": "improving",
+        "injury_risk": 2,
+        "fdr_next_3": 2.5,
+    }
+
+
+# --- embed_text tests ---
+
+
+@pytest.mark.unit
+def test_embed_text_returns_384_dims(embedder: PlayerEmbedder) -> None:
+    result = embedder.embed_text("Mohamed Salah is a top FPL midfielder.")
+    assert len(result) == 384
+
+
+@pytest.mark.unit
+def test_embed_text_returns_floats(embedder: PlayerEmbedder) -> None:
+    result = embedder.embed_text("Test input text.")
+    assert all(isinstance(x, float) for x in result)
+
+
+# --- embed_batch tests ---
+
+
+@pytest.mark.unit
+def test_embed_batch_returns_correct_count(embedder: PlayerEmbedder) -> None:
+    texts = ["Player one", "Player two", "Player three"]
+    result = embedder.embed_batch(texts)
+    assert len(result) == 3
+    assert all(len(v) == 384 for v in result)
+
+
+@pytest.mark.unit
+def test_embed_batch_empty_list(embedder: PlayerEmbedder) -> None:
+    result = embedder.embed_batch([])
+    assert result == []
+
+
+# --- build_profile_text tests ---
+
+
+@pytest.mark.unit
+def test_build_profile_text_includes_all_fields() -> None:
+    player = _complete_player()
+    text = PlayerEmbedder.build_profile_text(player)
+
+    assert "Salah" in text
+    assert "MID" in text
+    assert "Liverpool" in text
+    assert "13.0" in text
+    assert "8.2" in text
+    assert "180" in text
+    assert "15" in text
+    assert "10" in text
+    assert "Consistent performer" in text
+    assert "improving" in text
+    assert "2" in text
+    assert "2.5" in text
+
+
+@pytest.mark.unit
+def test_build_profile_text_handles_missing_fields() -> None:
+    player = {"web_name": "Salah", "position": "MID"}
+    text = PlayerEmbedder.build_profile_text(player)
+
+    assert "Salah" in text
+    assert "MID" in text
+    assert "N/A" in text
+    assert "No summary available" in text
+
+
+@pytest.mark.unit
+def test_build_profile_text_handles_none_values() -> None:
+    player = _complete_player()
+    player["llm_summary"] = None
+    player["form_trend"] = None
+    player["injury_risk"] = None
+    player["fdr_next_3"] = None
+
+    text = PlayerEmbedder.build_profile_text(player)
+
+    assert "Salah" in text
+    assert "No summary available" in text
+    assert "N/A" in text

--- a/services/agent/tests/test_sync_embeddings.py
+++ b/services/agent/tests/test_sync_embeddings.py
@@ -1,0 +1,215 @@
+"""Tests for sync_embeddings."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pyarrow as pa
+import pytest
+
+from fpl_agent.embeddings.embedder import PlayerEmbedder
+from fpl_agent.embeddings.sync_embeddings import sync_embeddings
+from fpl_lib.clients.neon import NeonClient
+from fpl_lib.clients.s3 import S3Client
+
+
+def _sample_players() -> list[dict]:
+    """Return a list of sample curated player dicts."""
+    return [
+        {
+            "player_id": 1,
+            "web_name": "Salah",
+            "team_name": "Liverpool",
+            "position": "MID",
+            "price": 13.0,
+            "total_points": 180,
+            "form": 8.2,
+            "goals_scored": 15,
+            "assists": 10,
+            "minutes": 2400,
+            "llm_summary": "Top scorer this season.",
+            "form_trend": "improving",
+            "injury_risk": 2,
+            "fdr_next_3": 2.5,
+        },
+        {
+            "player_id": 2,
+            "web_name": "Haaland",
+            "team_name": "Man City",
+            "position": "FWD",
+            "price": 14.5,
+            "total_points": 160,
+            "form": 7.0,
+            "goals_scored": 18,
+            "assists": 3,
+            "minutes": 2200,
+            "llm_summary": "Clinical finisher but rotation risk.",
+            "form_trend": "stable",
+            "injury_risk": 3,
+            "fdr_next_3": 3.0,
+        },
+        {
+            "player_id": 3,
+            "web_name": "Saka",
+            "team_name": "Arsenal",
+            "position": "MID",
+            "price": 10.0,
+            "total_points": 140,
+            "form": 6.5,
+            "goals_scored": 10,
+            "assists": 8,
+            "minutes": 2100,
+            "llm_summary": None,
+            "form_trend": None,
+            "injury_risk": None,
+            "fdr_next_3": None,
+        },
+    ]
+
+
+@pytest.fixture
+def mock_s3_client() -> MagicMock:
+    client = MagicMock(spec=S3Client)
+    table = pa.Table.from_pylist(_sample_players())
+    client.read_parquet.return_value = table
+    return client
+
+
+@pytest.fixture
+def mock_neon_client() -> AsyncMock:
+    client = AsyncMock(spec=NeonClient)
+    client.execute.return_value = "INSERT 0 1"
+    return client
+
+
+@pytest.fixture
+def mock_embedder() -> MagicMock:
+    emb = MagicMock(spec=PlayerEmbedder)
+    emb.build_profile_text.side_effect = lambda p: f"Profile for {p.get('web_name', 'Unknown')}"
+    emb.embed_batch.return_value = [[0.1] * 384, [0.2] * 384, [0.3] * 384]
+    return emb
+
+
+# --- sync_embeddings tests ---
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_sync_reads_curated_data(
+    mock_s3_client: MagicMock,
+    mock_neon_client: AsyncMock,
+    mock_embedder: MagicMock,
+) -> None:
+    await sync_embeddings(
+        s3_client=mock_s3_client,
+        neon_client=mock_neon_client,
+        embedder=mock_embedder,
+        bucket="test-bucket",
+        season="2025-26",
+        gameweek=10,
+    )
+    mock_s3_client.read_parquet.assert_called_once_with(
+        "test-bucket",
+        "curated/player_dashboard/season=2025-26/gameweek=10/player_dashboard.parquet",
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_sync_upserts_correct_count(
+    mock_s3_client: MagicMock,
+    mock_neon_client: AsyncMock,
+    mock_embedder: MagicMock,
+) -> None:
+    await sync_embeddings(
+        s3_client=mock_s3_client,
+        neon_client=mock_neon_client,
+        embedder=mock_embedder,
+        bucket="test-bucket",
+        season="2025-26",
+        gameweek=10,
+    )
+    assert mock_neon_client.execute.call_count == 3
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_sync_returns_correct_response(
+    mock_s3_client: MagicMock,
+    mock_neon_client: AsyncMock,
+    mock_embedder: MagicMock,
+) -> None:
+    result = await sync_embeddings(
+        s3_client=mock_s3_client,
+        neon_client=mock_neon_client,
+        embedder=mock_embedder,
+        bucket="test-bucket",
+        season="2025-26",
+        gameweek=10,
+    )
+    assert result["players_synced"] == 3
+    assert result["embedding_dim"] == 384
+    assert isinstance(result["duration_seconds"], float)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_sync_handles_empty_dataframe(
+    mock_neon_client: AsyncMock,
+    mock_embedder: MagicMock,
+) -> None:
+    empty_s3 = MagicMock(spec=S3Client)
+    empty_s3.read_parquet.return_value = pa.Table.from_pylist([])
+
+    result = await sync_embeddings(
+        s3_client=empty_s3,
+        neon_client=mock_neon_client,
+        embedder=mock_embedder,
+        bucket="test-bucket",
+        season="2025-26",
+        gameweek=1,
+    )
+    assert result["players_synced"] == 0
+    mock_neon_client.execute.assert_not_called()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_sync_handles_missing_enrichments(
+    mock_neon_client: AsyncMock,
+    mock_embedder: MagicMock,
+) -> None:
+    """Player with no enrichment fields should sync without error."""
+    sparse_player = [{"player_id": 99, "web_name": "Unknown", "position": "DEF"}]
+    sparse_s3 = MagicMock(spec=S3Client)
+    sparse_s3.read_parquet.return_value = pa.Table.from_pylist(sparse_player)
+    mock_embedder.embed_batch.return_value = [[0.0] * 384]
+
+    result = await sync_embeddings(
+        s3_client=sparse_s3,
+        neon_client=mock_neon_client,
+        embedder=mock_embedder,
+        bucket="test-bucket",
+        season="2025-26",
+        gameweek=5,
+    )
+    assert result["players_synced"] == 1
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_sync_passes_correct_s3_path(
+    mock_s3_client: MagicMock,
+    mock_neon_client: AsyncMock,
+    mock_embedder: MagicMock,
+) -> None:
+    """Gameweek should be zero-padded in the S3 key."""
+    await sync_embeddings(
+        s3_client=mock_s3_client,
+        neon_client=mock_neon_client,
+        embedder=mock_embedder,
+        bucket="my-bucket",
+        season="2024-25",
+        gameweek=3,
+    )
+    call_args = mock_s3_client.read_parquet.call_args
+    key = call_args[0][1]
+    assert "gameweek=03" in key


### PR DESCRIPTION
## Summary
- Add `NeonClient` async Postgres wrapper to shared lib (`fpl_lib.clients`) for pgvector operations
- Add `PlayerEmbedder` using sentence-transformers `all-MiniLM-L6-v2` (384-dim, local CPU, £0 cost)
- Add `sync_embeddings` pipeline: reads curated S3 data → generates embeddings → upserts into Neon
- Add Lambda handler (`sync_handler`) for Step Functions integration
- Add `player_embeddings` schema with IVFFlat vector index and structured filtering indexes

## What / Why / How
**What:** Vector database setup and embedding pipeline for the Phase 2 scout report agent.

**Why:** The agent needs two types of search — structured queries ("midfielders under £7m") and semantic similarity ("players like Palmer"). Neon pgvector provides both SQL and vector search in one serverless database (free tier, scales to zero).

**How:** `sync_embeddings` reads the curated `player_dashboard` Parquet from S3, builds a natural language profile per player (stats + enrichments), generates 384-dim embeddings via sentence-transformers, and upserts everything into the `player_embeddings` table. The Lambda handler retrieves the Neon connection string from Secrets Manager and registers the pgvector type.

Closes #88

## Test plan
- [x] `test_embed_text_returns_384_dims` — real model produces correct dimensions
- [x] `test_embed_text_returns_floats` — embedding values are floats
- [x] `test_embed_batch_returns_correct_count` — batch embedding preserves count
- [x] `test_embed_batch_empty_list` — empty input → empty output
- [x] `test_build_profile_text_includes_all_fields` — all player fields in profile text
- [x] `test_build_profile_text_handles_missing_fields` — partial data graceful
- [x] `test_build_profile_text_handles_none_values` — null enrichments graceful
- [x] `test_sync_reads_curated_data` — correct S3 path called
- [x] `test_sync_upserts_correct_count` — N players → N upserts
- [x] `test_sync_returns_correct_response` — response shape validated
- [x] `test_sync_handles_empty_dataframe` — no players → no upserts
- [x] `test_sync_handles_missing_enrichments` — sparse player data OK
- [x] `test_sync_passes_correct_s3_path` — gameweek zero-padded
- [x] `ruff check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)