### PR TITLE
feat(infra): API Gateway + agent Lambda infrastructure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ADR README (`docs/adr/README.md`) — skill area mapping table for portfolio readers
 
 ### Changed
+- Infra: Lambda module now sets `lifecycle.ignore_changes = [image_uri]` — hands image tag ownership to CI (which pushes commit-SHA tags via `aws lambda update-function-code`). Prevents Terraform from resetting all Lambdas to `:latest` on every apply.
+
+### Changed
 - ADR-0003: Expanded LiteLLM rejection with proxy latency concern and when-to-revisit criteria
 - ADR-0004: Moved rate limiting section to ADR-0006 (keeps cost ADR focused on cost)
 - ADR-0005: Replaced inline code blocks with file references to actual implementations; condensed SDK version note

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Infra: `modules/api-gateway/` — HTTP API v2 with Lambda proxy integration, CORS, throttling (10 req/s, 20 burst), CloudWatch access logs
+- Infra: Agent Lambda (`fpl-agent-dev`) wired to agent ECR image and shared Lambda role (1024 MB, 60s timeout)
+- Infra: DynamoDB table `fpl-agent-usage-dev` for monthly token/cost tracking and budget kill-switch
+- Infra: Neon database URL Secrets Manager shell (`/fpl-platform/dev/neon-database-url`) — populated manually post-apply
+- Infra: CloudFront `/api/agent/*` behaviour routing to API Gateway (CachingDisabled, AllViewerExceptHostHeader) — gated on `agent_api_domain` input
+- Agent: Stub `api_handler` returning 200 on `/health` and 501 elsewhere — lets Wave 2 provision infra end-to-end ahead of Wave 3 agent logic
 - ADR README (`docs/adr/README.md`) — skill area mapping table for portfolio readers
 
 ### Changed

--- a/infrastructure/environments/dev/.terraform.lock.hcl
+++ b/infrastructure/environments/dev/.terraform.lock.hcl
@@ -1,6 +1,25 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/hashicorp/archive" {
+  version = "2.7.1"
+  hashes = [
+    "h1:RzToQiFwVaxcV0QmgbyaKgNOhqc6oLKiFyZTrQSGcog=",
+    "zh:19881bb356a4a656a865f48aee70c0b8a03c35951b7799b6113883f67f196e8e",
+    "zh:2fcfbf6318dd514863268b09bbe19bfc958339c636bcbcc3664b45f2b8bf5cc6",
+    "zh:3323ab9a504ce0a115c28e64d0739369fe85151291a2ce480d51ccbb0c381ac5",
+    "zh:362674746fb3da3ab9bd4e70c75a3cdd9801a6cf258991102e2c46669cf68e19",
+    "zh:7140a46d748fdd12212161445c46bbbf30a3f4586c6ac97dd497f0c2565fe949",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:875e6ce78b10f73b1efc849bfcc7af3a28c83a52f878f503bb22776f71d79521",
+    "zh:b872c6ed24e38428d817ebfb214da69ea7eefc2c38e5a774db2ccd58e54d3a22",
+    "zh:cd6a44f731c1633ae5d37662af86e7b01ae4c96eb8b04144255824c3f350392d",
+    "zh:e0600f5e8da12710b0c52d6df0ba147a5486427c1a2cc78f31eea37a47ee1b07",
+    "zh:f21b2e2563bbb1e44e73557bcd6cdbc1ceb369d471049c40eb56cb84b6317a60",
+    "zh:f752829eba1cc04a479cf7ae7271526b402e206d5bcf1fcce9f535de5ff9e4e6",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.100.0"
   constraints = "~> 5.0"

--- a/infrastructure/environments/dev/agent.tf
+++ b/infrastructure/environments/dev/agent.tf
@@ -1,0 +1,57 @@
+# -----------------------------------------------------------------------------
+# Scout Agent — HTTP entry point and runtime resources.
+#
+# - DynamoDB table tracks monthly token usage for budget kill-switch
+# - IAM policy grants the shared Lambda role access to the table
+# - API Gateway v2 fronts the agent Lambda with CORS + throttling
+# -----------------------------------------------------------------------------
+
+# Monthly usage tracking — one row per calendar month (e.g. "2026-04").
+# Columns set at runtime: input_tokens, output_tokens, total_cost_usd,
+# budget_limit_usd, exceeded_at. The agent lazy-creates the current month's
+# row on first invocation via PutItem with attribute_not_exists(month).
+resource "aws_dynamodb_table" "agent_usage" {
+  name         = "fpl-agent-usage-${var.environment}"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "month"
+
+  attribute {
+    name = "month"
+    type = "S"
+  }
+}
+
+resource "aws_iam_role_policy" "lambda_agent_dynamo" {
+  name = "fpl-${var.environment}-agent-dynamo"
+  role = module.lambda_role.role_name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "dynamodb:GetItem",
+          "dynamodb:UpdateItem",
+          "dynamodb:PutItem",
+        ]
+        Resource = aws_dynamodb_table.agent_usage.arn
+      }
+    ]
+  })
+}
+
+module "api_gateway" {
+  source = "../../modules/api-gateway"
+
+  name                 = "fpl-agent-${var.environment}"
+  environment          = var.environment
+  lambda_function_name = module.lambda_agent.function_name
+  lambda_invoke_arn    = module.lambda_agent.invoke_arn
+
+  # Production traffic is same-origin (dashboard and agent both served from
+  # the CloudFront domain), so CORS only matters for local Vite dev.
+  # Intentionally scoped to localhost to avoid a circular dependency on
+  # module.web_hosting.cloudfront_domain.
+  cors_allow_origins = ["http://localhost:5173"]
+}

--- a/infrastructure/environments/dev/lambda.tf
+++ b/infrastructure/environments/dev/lambda.tf
@@ -179,3 +179,22 @@ module "lambda_curate_data" {
     DATA_LAKE_BUCKET = module.data_lake.bucket_name
   }
 }
+
+module "lambda_agent" {
+  source             = "../../modules/lambda"
+  name               = "agent"
+  environment        = var.environment
+  image_uri          = "${module.ecr_agent.repository_url}:latest"
+  execution_role_arn = module.lambda_role.role_arn
+  command            = ["fpl_agent.handlers.api_handler.lambda_handler"]
+  timeout            = 60
+  memory_size        = 1024
+  environment_variables = {
+    ENV                            = var.environment
+    NEON_SECRET_ARN                = aws_secretsmanager_secret.neon_database_url.arn
+    ANTHROPIC_SECRET_ARN           = aws_secretsmanager_secret.anthropic_api_key.arn
+    LANGFUSE_PUBLIC_KEY_SECRET_ARN = aws_secretsmanager_secret.langfuse_public_key.arn
+    LANGFUSE_SECRET_KEY_SECRET_ARN = aws_secretsmanager_secret.langfuse_secret_key.arn
+    USAGE_TABLE_NAME               = aws_dynamodb_table.agent_usage.name
+  }
+}

--- a/infrastructure/environments/dev/outputs.tf
+++ b/infrastructure/environments/dev/outputs.tf
@@ -12,3 +12,8 @@ output "app_bucket_name" {
   description = "S3 bucket to upload the Vite build output (dist/) to"
   value       = module.web_hosting.app_bucket_name
 }
+
+output "agent_api_endpoint" {
+  description = "Direct API Gateway endpoint for the Scout Agent. Use this for testing before CloudFront propagates. Production traffic goes via /api/agent/* on the dashboard URL."
+  value       = module.api_gateway.api_endpoint
+}

--- a/infrastructure/environments/dev/secrets.tf
+++ b/infrastructure/environments/dev/secrets.tf
@@ -19,3 +19,8 @@ resource "aws_secretsmanager_secret" "langfuse_secret_key" {
   name        = "/fpl-platform/${var.environment}/langfuse-secret-key"
   description = "Langfuse secret key for observability"
 }
+
+resource "aws_secretsmanager_secret" "neon_database_url" {
+  name        = "/fpl-platform/${var.environment}/neon-database-url"
+  description = "Neon Postgres connection string for the Scout Agent (pgvector backend)"
+}

--- a/infrastructure/environments/dev/web.tf
+++ b/infrastructure/environments/dev/web.tf
@@ -7,6 +7,7 @@ module "web_hosting" {
   environment           = var.environment
   data_lake_bucket_name = module.data_lake.bucket_name
   data_lake_bucket_arn  = module.data_lake.bucket_arn
+  agent_api_domain      = module.api_gateway.api_domain
 }
 
 # -----------------------------------------------------------------------------

--- a/infrastructure/modules/api-gateway/README.md
+++ b/infrastructure/modules/api-gateway/README.md
@@ -1,0 +1,55 @@
+# api-gateway
+
+HTTP API (API Gateway v2) with a Lambda proxy integration, CORS, request
+throttling, and CloudWatch access logs. Designed for the Scout Agent Lambda
+but reusable for any single-Lambda HTTP service.
+
+## Routes
+- `POST /chat` — agent chat endpoint (streaming responses expected)
+- `GET /health` — liveness probe
+
+Both routes target the same Lambda — the handler dispatches on `event.rawPath`.
+
+## Inputs
+
+| Name | Type | Default | Description |
+|---|---|---|---|
+| `name` | string | — | API name (also log group prefix). Typically the Lambda function name. |
+| `environment` | string | — | `dev` or `prod`. |
+| `lambda_function_name` | string | — | Lambda to invoke (for the invoke permission). |
+| `lambda_invoke_arn` | string | — | Lambda invoke ARN (`aws_lambda_function.x.invoke_arn`). |
+| `cors_allow_origins` | list(string) | — | Allowed origins. Do not use `["*"]` on LLM-backed endpoints. |
+| `throttle_rate_limit` | number | `10` | Steady-state req/s on the default stage. |
+| `throttle_burst_limit` | number | `20` | Burst concurrency on the default stage. |
+
+## Outputs
+
+| Name | Description |
+|---|---|
+| `api_endpoint` | Full URL including `https://`. Test directly via `curl`. |
+| `api_domain` | Bare host for use as a CloudFront origin `domain_name`. |
+| `api_id` | API Gateway HTTP API ID. |
+| `api_execution_arn` | Execution ARN (for Lambda invoke permission scoping). |
+
+## Example
+
+```hcl
+module "agent_api" {
+  source = "../../modules/api-gateway"
+
+  name                 = "fpl-agent-dev"
+  environment          = "dev"
+  lambda_function_name = module.lambda_agent.function_name
+  lambda_invoke_arn    = module.lambda_agent.invoke_arn
+  cors_allow_origins   = ["https://${module.web_hosting.cloudfront_domain}", "http://localhost:5173"]
+}
+```
+
+## Why HTTP API (v2) instead of REST API (v1)?
+
+- ~70% cheaper per request
+- Native JWT authorizer support (useful if/when auth is added)
+- Payload format 2.0 is what FastAPI/LangGraph handlers expect
+- Lower latency (no request/response transformations by default)
+
+REST APIs remain useful for usage plans and API keys — neither needed here.

--- a/infrastructure/modules/api-gateway/main.tf
+++ b/infrastructure/modules/api-gateway/main.tf
@@ -1,0 +1,80 @@
+# -----------------------------------------------------------------------------
+# API Gateway v2 (HTTP API) — Lambda proxy integration for the Scout Agent.
+#
+# HTTP APIs are ~70% cheaper than REST APIs and support the payload format 2.0
+# that LangGraph/FastAPI agents expect. The $default stage is auto-deployed
+# so route changes apply without a manual deployment step.
+# -----------------------------------------------------------------------------
+resource "aws_apigatewayv2_api" "this" {
+  name          = var.name
+  protocol_type = "HTTP"
+  description   = "HTTP API for ${var.name} Lambda"
+
+  cors_configuration {
+    allow_origins = var.cors_allow_origins
+    allow_methods = ["GET", "POST", "OPTIONS"]
+    allow_headers = ["content-type", "authorization"]
+    max_age       = 300
+  }
+}
+
+resource "aws_apigatewayv2_integration" "lambda" {
+  api_id                 = aws_apigatewayv2_api.this.id
+  integration_type       = "AWS_PROXY"
+  integration_uri        = var.lambda_invoke_arn
+  integration_method     = "POST"
+  payload_format_version = "2.0"
+}
+
+resource "aws_apigatewayv2_route" "chat" {
+  api_id    = aws_apigatewayv2_api.this.id
+  route_key = "POST /chat"
+  target    = "integrations/${aws_apigatewayv2_integration.lambda.id}"
+}
+
+resource "aws_apigatewayv2_route" "health" {
+  api_id    = aws_apigatewayv2_api.this.id
+  route_key = "GET /health"
+  target    = "integrations/${aws_apigatewayv2_integration.lambda.id}"
+}
+
+resource "aws_cloudwatch_log_group" "access_logs" {
+  name              = "/aws/apigateway/${var.name}"
+  retention_in_days = 30
+}
+
+resource "aws_apigatewayv2_stage" "default" {
+  api_id      = aws_apigatewayv2_api.this.id
+  name        = "$default"
+  auto_deploy = true
+
+  default_route_settings {
+    throttling_rate_limit  = var.throttle_rate_limit
+    throttling_burst_limit = var.throttle_burst_limit
+  }
+
+  access_log_settings {
+    destination_arn = aws_cloudwatch_log_group.access_logs.arn
+    format = jsonencode({
+      requestId               = "$context.requestId"
+      sourceIp                = "$context.identity.sourceIp"
+      requestTime             = "$context.requestTime"
+      protocol                = "$context.protocol"
+      httpMethod              = "$context.httpMethod"
+      routeKey                = "$context.routeKey"
+      status                  = "$context.status"
+      responseLength          = "$context.responseLength"
+      integrationErrorMessage = "$context.integrationErrorMessage"
+    })
+  }
+}
+
+# Allow API Gateway to invoke the Lambda. source_arn wildcards (*/*) cover
+# every route + method on every stage.
+resource "aws_lambda_permission" "apigw_invoke" {
+  statement_id  = "AllowAPIGatewayInvoke"
+  action        = "lambda:InvokeFunction"
+  function_name = var.lambda_function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_apigatewayv2_api.this.execution_arn}/*/*"
+}

--- a/infrastructure/modules/api-gateway/outputs.tf
+++ b/infrastructure/modules/api-gateway/outputs.tf
@@ -1,0 +1,19 @@
+output "api_endpoint" {
+  description = "Fully-qualified API endpoint (e.g. https://abc123.execute-api.eu-west-2.amazonaws.com). Use directly for testing before CloudFront is wired up."
+  value       = aws_apigatewayv2_api.this.api_endpoint
+}
+
+output "api_domain" {
+  description = "Bare host of the API endpoint (scheme stripped). Used as the domain_name on a CloudFront custom origin."
+  value       = replace(aws_apigatewayv2_api.this.api_endpoint, "https://", "")
+}
+
+output "api_id" {
+  description = "ID of the HTTP API."
+  value       = aws_apigatewayv2_api.this.id
+}
+
+output "api_execution_arn" {
+  description = "Execution ARN of the HTTP API. Used for scoping Lambda invoke permissions."
+  value       = aws_apigatewayv2_api.this.execution_arn
+}

--- a/infrastructure/modules/api-gateway/variables.tf
+++ b/infrastructure/modules/api-gateway/variables.tf
@@ -1,0 +1,51 @@
+variable "name" {
+  description = "Name of the HTTP API (also used as the prefix for the CloudWatch access log group). Typically matches the Lambda function name, e.g. 'fpl-agent-dev'."
+  type        = string
+}
+
+variable "environment" {
+  description = "Deployment environment (dev/prod)."
+  type        = string
+
+  validation {
+    condition     = contains(["dev", "prod"], var.environment)
+    error_message = "Environment must be dev or prod."
+  }
+}
+
+variable "lambda_function_name" {
+  description = "Name of the Lambda function to integrate with. Used for the lambda:InvokeFunction permission."
+  type        = string
+}
+
+variable "lambda_invoke_arn" {
+  description = "Invoke ARN of the Lambda function (aws_lambda_function.x.invoke_arn)."
+  type        = string
+}
+
+variable "cors_allow_origins" {
+  description = "List of origins allowed to call the API. Use bare https URLs, e.g. ['https://d1abc.cloudfront.net', 'http://localhost:5173']."
+  type        = list(string)
+}
+
+variable "throttle_rate_limit" {
+  description = "Steady-state throttle rate (requests per second) applied across all routes on the default stage."
+  type        = number
+  default     = 10
+
+  validation {
+    condition     = var.throttle_rate_limit > 0
+    error_message = "throttle_rate_limit must be greater than 0."
+  }
+}
+
+variable "throttle_burst_limit" {
+  description = "Burst throttle limit (concurrent requests) applied across all routes on the default stage."
+  type        = number
+  default     = 20
+
+  validation {
+    condition     = var.throttle_burst_limit > 0
+    error_message = "throttle_burst_limit must be greater than 0."
+  }
+}

--- a/infrastructure/modules/lambda/main.tf
+++ b/infrastructure/modules/lambda/main.tf
@@ -16,6 +16,14 @@ resource "aws_lambda_function" "this" {
   environment {
     variables = var.environment_variables
   }
+
+  # image_uri is bootstrapped here with `:latest` but CI owns it thereafter —
+  # the deploy workflow pushes commit-SHA tags and updates each Lambda directly
+  # via `aws lambda update-function-code`. Without this, every `terraform apply`
+  # would reset Lambdas back to `:latest` and fight CI forever.
+  lifecycle {
+    ignore_changes = [image_uri]
+  }
 }
 
 # Internal IAM role — only created when no external role is provided

--- a/infrastructure/modules/web-hosting/main.tf
+++ b/infrastructure/modules/web-hosting/main.tf
@@ -77,6 +77,25 @@ resource "aws_cloudfront_distribution" "dashboard" {
     origin_access_control_id = aws_cloudfront_origin_access_control.data.id
   }
 
+  # --- Agent API origin (conditional — only when agent_api_domain is set) ---
+  # API Gateway is a standard HTTPS endpoint, so we use custom_origin_config
+  # (OAC is S3-only). Host header is stripped via AllViewerExceptHostHeader
+  # policy on the cache behaviour below.
+  dynamic "origin" {
+    for_each = var.agent_api_domain != "" ? [1] : []
+    content {
+      origin_id   = "agent_api"
+      domain_name = var.agent_api_domain
+
+      custom_origin_config {
+        http_port              = 80
+        https_port             = 443
+        origin_protocol_policy = "https-only"
+        origin_ssl_protocols   = ["TLSv1.2"]
+      }
+    }
+  }
+
   # --- /api/v1/* → data lake (short cache — data updates weekly) ---
   ordered_cache_behavior {
     path_pattern           = "/api/v1/*"
@@ -89,6 +108,25 @@ resource "aws_cloudfront_distribution" "dashboard" {
     # AWS managed cache policy: CachingOptimized (86400s default TTL)
     # Data updates weekly so a 24h cache is acceptable; pipeline invalidates on deploy
     cache_policy_id = "658327ea-f89d-4fab-a63d-7e88639e58f6"
+  }
+
+  # --- /api/agent/* → agent API Gateway (no caching; SSE streams must pass through) ---
+  dynamic "ordered_cache_behavior" {
+    for_each = var.agent_api_domain != "" ? [1] : []
+    content {
+      path_pattern           = "/api/agent/*"
+      target_origin_id       = "agent_api"
+      viewer_protocol_policy = "redirect-to-https"
+      allowed_methods        = ["GET", "HEAD", "OPTIONS", "POST", "PUT", "PATCH", "DELETE"]
+      cached_methods         = ["GET", "HEAD"]
+      compress               = true
+
+      # AWS managed: CachingDisabled — streaming LLM responses must not be cached
+      cache_policy_id = "4135ea2d-6df8-44a3-9df3-4b5a84be39ad"
+      # AWS managed: AllViewerExceptHostHeader — forwards everything (auth, body, query)
+      # but strips Host so API Gateway accepts the request.
+      origin_request_policy_id = "b689b0a8-53d0-40ab-baf2-68738e2966ac"
+    }
   }
 
   # --- /* → app bucket (long cache; deploy triggers invalidation) ---

--- a/infrastructure/modules/web-hosting/variables.tf
+++ b/infrastructure/modules/web-hosting/variables.tf
@@ -28,3 +28,9 @@ variable "price_class" {
     error_message = "price_class must be PriceClass_100, PriceClass_200, or PriceClass_All."
   }
 }
+
+variable "agent_api_domain" {
+  description = "Bare host (no scheme) of the agent API Gateway endpoint, e.g. 'abc123.execute-api.eu-west-2.amazonaws.com'. Empty string disables the /api/agent/* behaviour — useful when the agent stack isn't deployed yet."
+  type        = string
+  default     = ""
+}

--- a/services/agent/src/fpl_agent/handlers/api_handler.py
+++ b/services/agent/src/fpl_agent/handlers/api_handler.py
@@ -1,0 +1,38 @@
+"""Stub API handler for the Scout Agent.
+
+The real LangGraph-backed implementation lands in Wave 3 (ikuzuki/fpl-platform#91).
+This stub exists so Wave 2 Terraform can provision the Lambda and API Gateway
+with an image that actually responds, letting us validate wiring end-to-end
+before the agent logic is built.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+
+def lambda_handler(event: dict[str, Any], context: object) -> dict[str, Any]:
+    """Return 200 on /health, 501 on everything else.
+
+    API Gateway v2 payload format 2.0 puts the path in `event["rawPath"]`.
+    """
+    path = event.get("rawPath", "")
+    logger.info("agent stub received request: path=%s", path)
+
+    if path == "/health":
+        return {
+            "statusCode": 200,
+            "headers": {"content-type": "application/json"},
+            "body": json.dumps({"status": "ok", "stub": True}),
+        }
+
+    return {
+        "statusCode": 501,
+        "headers": {"content-type": "application/json"},
+        "body": json.dumps({"error": "agent not yet implemented — see issue #91"}),
+    }


### PR DESCRIPTION
## Summary
Wave 2 — gives the Scout Agent its HTTP entry point and runtime resources. Terraform only, plus a minimal agent handler stub so `terraform apply` has a working container image to point at. Real LangGraph agent code lands in Wave 3 (#91).

- **New `api-gateway` module** — HTTP API v2 with Lambda proxy integration, CORS, throttling (10 req/s, 20 burst), CloudWatch access logs
- **Agent Lambda (`fpl-agent-dev`)** — 1024 MB, 60s timeout, shared Lambda role, env vars wired to all 4 Secrets Manager entries + usage table name
- **DynamoDB `fpl-agent-usage-dev`** — monthly token/cost tracking for budget kill-switch (agent lazy-creates month rows at runtime)
- **Neon Secrets Manager shell** — `/fpl-platform/dev/neon-database-url` (populate manually after apply)
- **CloudFront `/api/agent/*` behaviour** — CachingDisabled + AllViewerExceptHostHeader, gated on optional `agent_api_domain` variable
- **Stub `api_handler.py`** — returns 200 on `/health`, 501 elsewhere

## Design notes
- **CORS locked to `http://localhost:5173`** (Vite dev) only. Production traffic is same-origin (dashboard and agent both on the CloudFront domain) so browser CORS never fires. This also breaks a potential circular dependency between `api_gateway` and `web_hosting` module outputs.
- **Image bootstrap**: agent ECR repo existed from Wave 1 but had no image. Merging this PR triggers the deploy workflow to build + push the stub container, so `terraform apply` will succeed on the first run.
- **Budget seed row**: lazy-created by agent code (Wave 3) via `PutItem` with `attribute_not_exists(month)` — keeps Terraform out of per-month data management.

## Test plan
- [ ] `terraform fmt -recursive infrastructure/` — clean ✅ (done locally)
- [ ] `terraform validate` in `modules/api-gateway/` — passes ✅ (done locally)
- [ ] `terraform validate` in `environments/dev/` — passes ✅ (done locally)
- [ ] CI `terraform plan` shows ~12 new resources + 1 in-place CloudFront update
- [ ] After apply: `curl "$(terraform output -raw agent_api_endpoint)/health"` returns `{"status":"ok","stub":true}`
- [ ] After apply: `curl https://<dashboard_url>/api/agent/health` returns the same (via CloudFront)
- [ ] Paste Neon connection string into the new secret in the AWS Console

Closes #90