### PR TITLE
fix(infra): strip /api/agent prefix via CloudFront Function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Infra: Lambda module now sets `lifecycle.ignore_changes = [image_uri]` — hands image tag ownership to CI (which pushes commit-SHA tags via `aws lambda update-function-code`). Prevents Terraform from resetting all Lambdas to `:latest` on every apply.
 
+### Fixed
+- Infra: CloudFront Function strips `/api/agent` prefix before forwarding to API Gateway — without this, the agent route returned the dashboard SPA HTML via the 404 fallback (API Gateway has no `/api/agent/*` routes, only `/chat` and `/health`).
+
 ### Changed
 - ADR-0003: Expanded LiteLLM rejection with proxy latency concern and when-to-revisit criteria
 - ADR-0004: Moved rate limiting section to ADR-0006 (keeps cost ADR focused on cost)

--- a/infrastructure/modules/web-hosting/main.tf
+++ b/infrastructure/modules/web-hosting/main.tf
@@ -126,6 +126,15 @@ resource "aws_cloudfront_distribution" "dashboard" {
       # AWS managed: AllViewerExceptHostHeader — forwards everything (auth, body, query)
       # but strips Host so API Gateway accepts the request.
       origin_request_policy_id = "b689b0a8-53d0-40ab-baf2-68738e2966ac"
+
+      # Strip the /api/agent prefix before forwarding to API Gateway.
+      # CloudFront's path_pattern selects which origin to use but doesn't
+      # rewrite the URL — so without this function, API Gateway would
+      # receive GET /api/agent/health instead of GET /health and 404.
+      function_association {
+        event_type   = "viewer-request"
+        function_arn = aws_cloudfront_function.strip_agent_prefix[0].arn
+      }
     }
   }
 
@@ -165,6 +174,35 @@ resource "aws_cloudfront_distribution" "dashboard" {
   viewer_certificate {
     cloudfront_default_certificate = true
   }
+}
+
+# -----------------------------------------------------------------------------
+# CloudFront Function — strip /api/agent prefix before forwarding to API Gateway
+#
+# CloudFront's ordered_cache_behavior.path_pattern selects the origin but does
+# not modify the URL. API Gateway's routes are /health and /chat (no prefix),
+# so the prefix has to be stripped on the way out.
+#
+# Runs at viewer-request (every request), ~1ms latency, free up to 10M/month.
+# -----------------------------------------------------------------------------
+resource "aws_cloudfront_function" "strip_agent_prefix" {
+  count = var.agent_api_domain != "" ? 1 : 0
+
+  name    = "fpl-${var.environment}-strip-agent-prefix"
+  runtime = "cloudfront-js-2.0"
+  publish = true
+  comment = "Strips /api/agent from the request URI before forwarding to API Gateway"
+
+  code = <<-EOT
+    function handler(event) {
+      var request = event.request;
+      request.uri = request.uri.replace(/^\/api\/agent/, '');
+      if (request.uri === '') {
+        request.uri = '/';
+      }
+      return request;
+    }
+  EOT
 }
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Missed this in #112. The CloudFront `/api/agent/*` behaviour was wired to API Gateway but didn't rewrite the URL, so API Gateway received `GET /api/agent/health` instead of `GET /health` and returned 404 — which CloudFront caught and served as `index.html` via the SPA fallback.

This PR adds a CloudFront Function (viewer-request trigger) that strips the `/api/agent` prefix before the request hits API Gateway.

## Verification (before/after)

**Before (main):**
\`\`\`
$ curl https://<dashboard>/api/agent/health
<!doctype html><html lang="en">... dashboard HTML ...
\`\`\`

**After (this PR, expected post-apply):**
\`\`\`
$ curl https://<dashboard>/api/agent/health
{"status":"ok","stub":true}
\`\`\`

Direct API Gateway calls were unaffected by the bug and remain unaffected by the fix — `curl "$(terraform output -raw agent_api_endpoint)/health"` still works without the prefix.

## Why a CloudFront Function (not alternatives)
- **Not API Gateway route duplication** (`/api/agent/health`): leaks the CloudFront URL structure into API Gateway, direct calls would need the prefix too
- **Not Lambda-level handling**: mixes transport concerns with business logic, worse once Wave 3 brings FastAPI
- **CloudFront Function**: runs at edge, ~1ms latency, free up to 10M/month, keeps the prefix concern inside CloudFront where it belongs

## Test plan
- [ ] `terraform plan` shows 1 new resource (`aws_cloudfront_function.strip_agent_prefix`) and 1 in-place CloudFront update (adds `function_association`)
- [ ] After apply (+15 min CloudFront propagation): `curl https://<dashboard>/api/agent/health` returns `{"status":"ok","stub":true}`
- [ ] Direct API Gateway still works: `curl "$(terraform output -raw agent_api_endpoint)/health"` returns the same