### PR TITLE
fix(pipeline): refresh bootstrap/fixtures weekly; label advice pages with upcoming GW

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Infra: CloudFront Function strips `/api/agent` prefix before forwarding to API Gateway — without this, the agent route returned the dashboard SPA HTML via the 404 fallback (API Gateway has no `/api/agent/*` routes, only `/chat` and `/health`).
+- Data: `FPLAPICollector.collect_bootstrap` and `collect_fixtures` no longer skip when prior output exists under the S3 prefix. Their source data (prices, player status, news, kickoff times, per-match stats) changes throughout the season, so every weekly pipeline run now writes a fresh timestamped snapshot. Downstream consumers already pick the latest via `sorted(list_objects(prefix))[-1]`. Gameweek-live and player-history keep their skip (both are frozen once captured).
+- Web: Briefing and Captain Picker pages now label themselves with the *upcoming* gameweek instead of the finished gameweek the underlying data was collected from. Curator writes a new `advice_gameweek` field (`gameweek + 1`, capped at 38) into `gameweek_briefing.json` and each `player_dashboard.json` row; the UI prefers that field and falls back to `gameweek + 1` when reading older JSON. Processed-GW stays in the `gameweek` field for Parquet analytics.
 
 ### Changed
 - ADR-0003: Expanded LiteLLM rejection with proxy latency concern and when-to-revisit criteria

--- a/services/curate/src/fpl_curate/curators/gameweek_briefing.py
+++ b/services/curate/src/fpl_curate/curators/gameweek_briefing.py
@@ -16,6 +16,7 @@ def build_gameweek_briefing(
     team_map: dict[int, dict[str, str]],
     season: str,
     gameweek: int,
+    advice_gameweek: int | None = None,
 ) -> dict[str, Any]:
     """Build a gameweek briefing from existing curated data.
 
@@ -25,7 +26,10 @@ def build_gameweek_briefing(
         fixture_fdr: Team ID -> {"next_3", "next_6"} FDR averages.
         team_map: Team ID -> {"name", "short_name"} mapping.
         season: Season identifier.
-        gameweek: Current gameweek number.
+        gameweek: Gameweek the underlying data was collected for (finished GW).
+        advice_gameweek: Gameweek this briefing gives advice for — typically
+            ``gameweek + 1``. ``None`` at end-of-season. UI renders this as the
+            page label so users see next-GW advice.
 
     Returns:
         Structured briefing dict for JSON serialisation.
@@ -144,6 +148,7 @@ def build_gameweek_briefing(
     briefing = {
         "season": season,
         "gameweek": gameweek,
+        "advice_gameweek": advice_gameweek,
         "top_picks": top_picks,
         "sell_alerts": sell_alerts,
         "injury_alerts": injury_alerts[:5],

--- a/services/curate/src/fpl_curate/curators/models.py
+++ b/services/curate/src/fpl_curate/curators/models.py
@@ -78,6 +78,10 @@ class PlayerDashboardRow(BaseModel):
     season: str
     gameweek: int
 
+    # Gameweek the dashboard advises on (typically gameweek + 1; None at end-of-season).
+    # Used by the Captain Picker UI as its page label.
+    advice_gameweek: int | None = None
+
 
 class FixtureTickerRow(BaseModel):
     """One row in the fixture ticker — one team's fixture in one gameweek."""

--- a/services/curate/src/fpl_curate/curators/player_dashboard.py
+++ b/services/curate/src/fpl_curate/curators/player_dashboard.py
@@ -18,6 +18,7 @@ def build_player_dashboard(
     weights: dict[str, float] | None,
     season: str,
     gameweek: int,
+    advice_gameweek: int | None = None,
 ) -> list[dict[str, Any]]:
     """Build the player dashboard curated dataset.
 
@@ -27,7 +28,10 @@ def build_player_dashboard(
         fixture_fdr: Team ID -> {"next_3", "next_6"} FDR averages.
         weights: FPL score component weights.
         season: Season identifier.
-        gameweek: Current gameweek number.
+        gameweek: Gameweek the underlying data was collected for (finished GW).
+        advice_gameweek: Gameweek this dashboard advises on — typically
+            ``gameweek + 1``. ``None`` at end-of-season. The Captain Picker UI
+            renders this instead of ``gameweek``.
 
     Returns:
         List of dicts ready for Pydantic validation / Parquet write.
@@ -124,6 +128,7 @@ def build_player_dashboard(
                 # Partition
                 "season": season,
                 "gameweek": gameweek,
+                "advice_gameweek": advice_gameweek,
             }
         )
 

--- a/services/curate/src/fpl_curate/handlers/curate_all.py
+++ b/services/curate/src/fpl_curate/handlers/curate_all.py
@@ -25,6 +25,26 @@ OPTIONAL_PARAMS = ["output_bucket", "force"]
 SCHEMA_VERSION = "1.0.0"
 
 
+def _log_advice_gameweek_sanity(
+    bootstrap_data: dict[str, Any], gameweek: int, advice_gameweek: int | None
+) -> None:
+    """Warn if bootstrap's is_next disagrees with our derived advice_gameweek.
+
+    Derived value is always ``gameweek + 1`` (capped at 38). Bootstrap's ``is_next``
+    reflects the *current* live state, which only matches for weekly scheduled runs —
+    a manual backfill of an old GW will disagree and that's expected.
+    """
+    events = bootstrap_data.get("events", [])
+    next_from_bootstrap = next((e["id"] for e in events if e.get("is_next")), None)
+    if next_from_bootstrap is not None and next_from_bootstrap != advice_gameweek:
+        logger.info(
+            "advice_gameweek=%s (gw+1) differs from bootstrap is_next=%s — "
+            "likely a manual backfill of a past GW",
+            advice_gameweek,
+            next_from_bootstrap,
+        )
+
+
 def _init_langfuse(region: str = "eu-west-2") -> None:
     """Initialise Langfuse with keys from Secrets Manager."""
     import os
@@ -105,6 +125,14 @@ async def main(
 
     team_map = build_team_map(bootstrap_data)
 
+    # Advice pages (Briefing, Captain Picker) label themselves with the *upcoming*
+    # GW, not the GW whose data we processed. `gameweek + 1` works for both scheduled
+    # runs and manual backfills (backfilling GW25 produces a briefing labelled GW26,
+    # matching what would have been advised at that point in history). None at season
+    # end — the UI hides the label if absent.
+    advice_gameweek = gameweek + 1 if gameweek < 38 else None
+    _log_advice_gameweek_sanity(bootstrap_data, gameweek, advice_gameweek)
+
     # --- Build curated datasets ---
 
     # 1. Fixture ticker (needed first — provides FDR lookup for scoring)
@@ -123,6 +151,7 @@ async def main(
         weights=settings.FPL_SCORE_WEIGHTS,
         season=season,
         gameweek=gameweek,
+        advice_gameweek=advice_gameweek,
     )
 
     # 3. Transfer picks (derived from dashboard)
@@ -149,6 +178,7 @@ async def main(
         team_map=team_map,
         season=season,
         gameweek=gameweek,
+        advice_gameweek=advice_gameweek,
     )
 
     # --- Write outputs ---

--- a/services/curate/tests/test_curate_all_handler.py
+++ b/services/curate/tests/test_curate_all_handler.py
@@ -115,6 +115,79 @@ class TestCurateAllHandler:
         assert mock_s3_client.write_parquet.call_count == 4
 
     @pytest.mark.asyncio
+    async def test_briefing_carries_advice_gameweek(
+        self,
+        mock_s3_client: MagicMock,
+        mock_settings: CurateSettings,
+        sample_enriched_df: pd.DataFrame,
+        sample_bootstrap: dict[str, Any],
+        sample_fixtures: list[dict[str, Any]],
+    ) -> None:
+        """The briefing JSON published for the UI must label itself with the
+        advice-target GW (processed GW + 1), not the processed GW."""
+        table = pa.Table.from_pandas(sample_enriched_df)
+        mock_s3_client.read_parquet.return_value = table
+        mock_s3_client.list_objects.side_effect = [
+            ["raw/fpl-api/season=2025-26/fixtures/2026-04-05.json"],
+            ["raw/fpl-api/season=2025-26/bootstrap/2026-04-05.json"],
+        ]
+        mock_s3_client.read_json.side_effect = [sample_fixtures, sample_bootstrap]
+
+        with (
+            patch("fpl_curate.handlers.curate_all.S3Client", return_value=mock_s3_client),
+            patch("fpl_curate.handlers.curate_all.get_curate_settings", return_value=mock_settings),
+        ):
+            await main(season="2025-26", gameweek=31, force=True)
+
+        briefing_call = next(
+            c
+            for c in mock_s3_client.put_json.call_args_list
+            if c.args[1] == "public/api/v1/gameweek_briefing.json"
+        )
+        briefing = briefing_call.args[2]
+        assert briefing["gameweek"] == 31
+        assert briefing["advice_gameweek"] == 32
+
+        dashboard_call = next(
+            c
+            for c in mock_s3_client.put_json.call_args_list
+            if c.args[1] == "public/api/v1/player_dashboard.json"
+        )
+        dashboard_rows = dashboard_call.args[2]
+        assert all(r["advice_gameweek"] == 32 for r in dashboard_rows)
+
+    @pytest.mark.asyncio
+    async def test_advice_gameweek_none_at_season_end(
+        self,
+        mock_s3_client: MagicMock,
+        mock_settings: CurateSettings,
+        sample_enriched_df: pd.DataFrame,
+        sample_bootstrap: dict[str, Any],
+        sample_fixtures: list[dict[str, Any]],
+    ) -> None:
+        """Processing GW38 (final GW) has no next GW — advice label must be None."""
+        table = pa.Table.from_pandas(sample_enriched_df)
+        mock_s3_client.read_parquet.return_value = table
+        mock_s3_client.list_objects.side_effect = [
+            ["raw/fpl-api/season=2025-26/fixtures/k.json"],
+            ["raw/fpl-api/season=2025-26/bootstrap/k.json"],
+        ]
+        mock_s3_client.read_json.side_effect = [sample_fixtures, sample_bootstrap]
+
+        with (
+            patch("fpl_curate.handlers.curate_all.S3Client", return_value=mock_s3_client),
+            patch("fpl_curate.handlers.curate_all.get_curate_settings", return_value=mock_settings),
+        ):
+            await main(season="2025-26", gameweek=38, force=True)
+
+        briefing_call = next(
+            c
+            for c in mock_s3_client.put_json.call_args_list
+            if c.args[1] == "public/api/v1/gameweek_briefing.json"
+        )
+        assert briefing_call.args[2]["advice_gameweek"] is None
+
+    @pytest.mark.asyncio
     async def test_fails_when_no_fixtures(
         self,
         mock_s3_client: MagicMock,

--- a/services/curate/tests/test_gameweek_briefing.py
+++ b/services/curate/tests/test_gameweek_briefing.py
@@ -112,6 +112,19 @@ class TestBuildGameweekBriefing:
         assert "summary_stats" in result
         assert result["season"] == "2025-26"
         assert result["gameweek"] == 31
+        # advice_gameweek defaults to None when the caller omits it
+        assert result["advice_gameweek"] is None
+
+    def test_advice_gameweek_is_propagated(
+        self,
+        sample_data: tuple,
+    ) -> None:
+        dashboard, transfers, fdr, teams = sample_data
+        result = build_gameweek_briefing(
+            dashboard, transfers, fdr, teams, "2025-26", 31, advice_gameweek=32
+        )
+        assert result["advice_gameweek"] == 32
+        assert result["gameweek"] == 31, "source gameweek must remain unchanged"
 
     def test_top_picks_are_buy_recommendations(
         self,

--- a/services/curate/tests/test_player_dashboard.py
+++ b/services/curate/tests/test_player_dashboard.py
@@ -188,3 +188,33 @@ class TestBuildPlayerDashboard:
         )
         rows = build_player_dashboard(df, team_map, fixture_fdr, None, "2025-26", 31)
         assert len(rows) == 0
+
+    def test_advice_gameweek_is_included_when_supplied(
+        self,
+        sample_enriched_df: pd.DataFrame,
+        team_map: dict[int, dict[str, str]],
+        fixture_fdr: dict[int, dict[str, float]],
+    ) -> None:
+        """Every row must carry the advice_gameweek label for the Captain Picker UI."""
+        rows = build_player_dashboard(
+            sample_enriched_df,
+            team_map,
+            fixture_fdr,
+            None,
+            "2025-26",
+            31,
+            advice_gameweek=32,
+        )
+        assert all(r["advice_gameweek"] == 32 for r in rows)
+        assert all(r["gameweek"] == 31 for r in rows), "source gameweek must remain unchanged"
+
+    def test_advice_gameweek_defaults_to_none(
+        self,
+        sample_enriched_df: pd.DataFrame,
+        team_map: dict[int, dict[str, str]],
+        fixture_fdr: dict[int, dict[str, float]],
+    ) -> None:
+        rows = build_player_dashboard(
+            sample_enriched_df, team_map, fixture_fdr, None, "2025-26", 31
+        )
+        assert all(r["advice_gameweek"] is None for r in rows)

--- a/services/data/src/fpl_data/collectors/fpl_api_collector.py
+++ b/services/data/src/fpl_data/collectors/fpl_api_collector.py
@@ -24,21 +24,20 @@ class FPLAPICollector:
         self.output_bucket = output_bucket
         self._bootstrap_cache: dict | None = None
 
-    async def collect_bootstrap(self, season: str, *, force: bool = False) -> CollectionResponse:
+    async def collect_bootstrap(self, season: str) -> CollectionResponse:
         """Collect bootstrap-static data (all players, teams, gameweeks).
+
+        Always re-fetches: bootstrap fields (prices, status, news, event flags) change
+        throughout the season, so every run writes a fresh timestamped snapshot.
+        Downstream consumers pick the latest by lexical sort of the prefix.
 
         Args:
             season: Season identifier, e.g. "2025-26".
-            force: If True, overwrite existing data.
 
         Returns:
             CollectionResponse with records_collected = number of player elements.
         """
         prefix = f"raw/fpl-api/season={season}/bootstrap/"
-        if not force and self._output_exists(prefix):
-            logger.info("Bootstrap data already exists for season=%s, skipping", season)
-            return CollectionResponse(status="success", records_collected=0, output_path=prefix)
-
         data = await self._fetch_bootstrap()
         timestamp = datetime.now(UTC).isoformat()
         key = f"{prefix}{timestamp}.json"
@@ -48,21 +47,20 @@ class FPLAPICollector:
         logger.info("Collected bootstrap: %d players for season=%s", records, season)
         return CollectionResponse(status="success", records_collected=records, output_path=key)
 
-    async def collect_fixtures(self, season: str, *, force: bool = False) -> CollectionResponse:
+    async def collect_fixtures(self, season: str) -> CollectionResponse:
         """Collect all fixtures for the season.
+
+        Always re-fetches: fixture kickoff times, postponements, and per-match stats
+        (populated as matches play) change throughout the season. Each run writes a
+        fresh timestamped snapshot; downstream consumers pick the latest by lexical sort.
 
         Args:
             season: Season identifier, e.g. "2025-26".
-            force: If True, overwrite existing data.
 
         Returns:
             CollectionResponse with records_collected = number of fixtures.
         """
         prefix = f"raw/fpl-api/season={season}/fixtures/"
-        if not force and self._output_exists(prefix):
-            logger.info("Fixtures data already exists for season=%s, skipping", season)
-            return CollectionResponse(status="success", records_collected=0, output_path=prefix)
-
         data = await fpl_fetch(f"{FPL_BASE_URL}/fixtures/")
         timestamp = datetime.now(UTC).isoformat()
         key = f"{prefix}{timestamp}.json"

--- a/services/data/src/fpl_data/handlers/fpl_api_handler.py
+++ b/services/data/src/fpl_data/handlers/fpl_api_handler.py
@@ -30,7 +30,9 @@ async def main(
         gameweek: Gameweek number (1-38).
         output_bucket: S3 bucket for output.
         endpoints: List of endpoints to collect. Defaults to bootstrap + fixtures + live.
-        force: If True, overwrite existing data.
+        force: If True, re-collect the gameweek-live snapshot even if one already
+            exists. Bootstrap and fixtures are always re-fetched (their data is
+            season-volatile), so this flag does not affect them.
 
     Returns:
         Dict with list of CollectionResponse results.
@@ -43,9 +45,9 @@ async def main(
 
     for endpoint in active_endpoints:
         if endpoint == "bootstrap":
-            resp = await collector.collect_bootstrap(season, force=force)
+            resp = await collector.collect_bootstrap(season)
         elif endpoint == "fixtures":
-            resp = await collector.collect_fixtures(season, force=force)
+            resp = await collector.collect_fixtures(season)
         elif endpoint == "live":
             resp = await collector.collect_gameweek_live(season, gameweek, force=force)
         else:

--- a/services/data/tests/test_fpl_api_collector.py
+++ b/services/data/tests/test_fpl_api_collector.py
@@ -88,44 +88,27 @@ async def test_collect_bootstrap_success(
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_collect_bootstrap_skips_if_exists(
-    collector: FPLAPICollector,
-    mock_s3_client: MagicMock,
-) -> None:
-    mock_s3_client.list_objects.return_value = [
-        "raw/fpl-api/season=2025-26/bootstrap/existing.json"
-    ]
-
-    with patch(
-        "fpl_data.collectors.fpl_api_collector.fpl_fetch", new_callable=AsyncMock
-    ) as mock_fetch:
-        result = await collector.collect_bootstrap("2025-26")
-
-    mock_fetch.assert_not_called()
-    mock_s3_client.put_json.assert_not_called()
-    assert result.records_collected == 0
-
-
-@pytest.mark.unit
-@pytest.mark.asyncio
-async def test_collect_bootstrap_force_overwrites(
+async def test_collect_bootstrap_always_fetches_even_if_exists(
     collector: FPLAPICollector,
     mock_s3_client: MagicMock,
     bootstrap_response: dict,
 ) -> None:
+    """Bootstrap is season-volatile (prices, status, news), so a prior snapshot
+    under the prefix must not cause the collector to skip."""
     mock_s3_client.list_objects.return_value = [
-        "raw/fpl-api/season=2025-26/bootstrap/existing.json"
+        "raw/fpl-api/season=2025-26/bootstrap/earlier.json"
     ]
 
     with patch(
         "fpl_data.collectors.fpl_api_collector.fpl_fetch",
         new_callable=AsyncMock,
         return_value=bootstrap_response,
-    ):
-        result = await collector.collect_bootstrap("2025-26", force=True)
+    ) as mock_fetch:
+        result = await collector.collect_bootstrap("2025-26")
 
-    assert result.records_collected == 3
+    mock_fetch.assert_called_once()
     mock_s3_client.put_json.assert_called_once()
+    assert result.records_collected == 3
 
 
 @pytest.mark.unit
@@ -171,19 +154,27 @@ async def test_collect_fixtures_success(
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_collect_fixtures_skips_if_exists(
+async def test_collect_fixtures_always_fetches_even_if_exists(
     collector: FPLAPICollector,
     mock_s3_client: MagicMock,
+    fixtures_response: list,
 ) -> None:
-    mock_s3_client.list_objects.return_value = ["existing.json"]
+    """Fixtures change (kickoff times, postponements, per-match stats), so a
+    prior snapshot must not cause the collector to skip."""
+    mock_s3_client.list_objects.return_value = [
+        "raw/fpl-api/season=2025-26/fixtures/earlier.json"
+    ]
 
     with patch(
-        "fpl_data.collectors.fpl_api_collector.fpl_fetch", new_callable=AsyncMock
+        "fpl_data.collectors.fpl_api_collector.fpl_fetch",
+        new_callable=AsyncMock,
+        return_value=fixtures_response,
     ) as mock_fetch:
         result = await collector.collect_fixtures("2025-26")
 
-    mock_fetch.assert_not_called()
-    assert result.records_collected == 0
+    mock_fetch.assert_called_once()
+    mock_s3_client.put_json.assert_called_once()
+    assert result.records_collected == 2
 
 
 # --- collect_gameweek_live tests ---

--- a/services/data/tests/test_fpl_api_collector.py
+++ b/services/data/tests/test_fpl_api_collector.py
@@ -95,9 +95,7 @@ async def test_collect_bootstrap_always_fetches_even_if_exists(
 ) -> None:
     """Bootstrap is season-volatile (prices, status, news), so a prior snapshot
     under the prefix must not cause the collector to skip."""
-    mock_s3_client.list_objects.return_value = [
-        "raw/fpl-api/season=2025-26/bootstrap/earlier.json"
-    ]
+    mock_s3_client.list_objects.return_value = ["raw/fpl-api/season=2025-26/bootstrap/earlier.json"]
 
     with patch(
         "fpl_data.collectors.fpl_api_collector.fpl_fetch",
@@ -161,9 +159,7 @@ async def test_collect_fixtures_always_fetches_even_if_exists(
 ) -> None:
     """Fixtures change (kickoff times, postponements, per-match stats), so a
     prior snapshot must not cause the collector to skip."""
-    mock_s3_client.list_objects.return_value = [
-        "raw/fpl-api/season=2025-26/fixtures/earlier.json"
-    ]
+    mock_s3_client.list_objects.return_value = ["raw/fpl-api/season=2025-26/fixtures/earlier.json"]
 
     with patch(
         "fpl_data.collectors.fpl_api_collector.fpl_fetch",

--- a/web/dashboard/src/lib/types.ts
+++ b/web/dashboard/src/lib/types.ts
@@ -50,6 +50,7 @@ export interface PlayerDashboard {
   score_injury: number | null;
   season: string;
   gameweek: number;
+  advice_gameweek?: number | null;
 }
 
 export interface BriefingPick {
@@ -84,6 +85,7 @@ export interface BriefingFixture {
 export interface GameweekBriefing {
   season: string;
   gameweek: number;
+  advice_gameweek?: number | null;
   top_picks: BriefingPick[];
   sell_alerts: { player_id: number; web_name: string; team_short: string; position: string; fpl_score: number; reasons: string[] }[];
   injury_alerts: BriefingAlert[];

--- a/web/dashboard/src/pages/BriefingPage.tsx
+++ b/web/dashboard/src/pages/BriefingPage.tsx
@@ -54,13 +54,15 @@ export function BriefingPage() {
     );
   }
 
+  const displayGw = data.advice_gameweek ?? data.gameweek + 1;
+
   return (
     <div className="space-y-6">
       {/* Header */}
       <div className="flex items-center justify-between flex-wrap gap-3">
         <div>
           <h1 className="text-3xl font-bold">
-            GW{data.gameweek} Briefing
+            GW{displayGw} Briefing
           </h1>
           <p className="text-[var(--muted-foreground)] text-sm mt-1">
             {data.summary_stats.total_players} players analysed &middot;{" "}

--- a/web/dashboard/src/pages/CaptainPage.tsx
+++ b/web/dashboard/src/pages/CaptainPage.tsx
@@ -148,7 +148,10 @@ export function CaptainPage() {
     };
   }, [top15]);
 
-  const gameweek = players[0]?.gameweek ?? "?";
+  const first = players[0];
+  const gameweek =
+    first?.advice_gameweek ??
+    (first?.gameweek !== undefined ? first.gameweek + 1 : "?");
 
   if (loading) return <TableSkeleton rows={12} />;
   if (error) return <ErrorCard message={error} />;


### PR DESCRIPTION
## Summary

Two related pipeline-freshness fixes surfaced from CloudWatch inspection of a real run:

- **Bootstrap + fixtures were being skipped every weekly run.** The collector's skip-if-prefix-exists logic was correct for frozen data (gameweek-live, player-history) but wrong for these two endpoints, whose fields (prices, player status, news, kickoff times, per-match stats) change throughout the season. Every downstream stage has been silently reading a stale snapshot taken at first collection. Now they always re-fetch; downstream consumers (`validator`, `transform`, `curate_all`, `single_enricher`) already use `sorted(list_objects(prefix))[-1]` so they transparently pick the newest.
- **Briefing and Captain Picker pages were labelled with the finished GW, not the upcoming one.** `GW32 Briefing` was displayed after GW32's data was processed, but those pages advise on GW33. Curator now publishes a new `advice_gameweek` field (= `gameweek + 1`, capped at 38; `None` at season end). Deriving from `gameweek + 1` rather than bootstrap's `is_next` keeps manual backfills correct — backfilling GW25 produces a briefing labelled GW26, matching the advice that would have been given at that point. The Step Function is unchanged; derivation happens inside the curator so it works on both auto and manual triggers.

The UI prefers `advice_gameweek` and falls back to `gameweek + 1` so the dashboard keeps working against older JSON until the next curate run republishes.

Processed-GW stays in the `gameweek` field for Parquet analytics and debugging.

## Test plan

- [x] `ruff check` — clean on `services/data` and `services/curate`
- [x] `pytest services/data` — 58/58 pass (15 on collector)
- [x] `pytest services/curate` — 64/64 pass (including 4 new advice_gameweek tests)
- [x] `tsc -b` in `web/dashboard` — clean
- [x] Step Function template (`infrastructure/step_function_definitions/fpl-collection-pipeline.json.tpl`) validates as JSON and still passes `force` through to the collector Lambda
- [ ] After merge + deploy: trigger a manual pipeline run and verify the Briefing page labels itself with the *upcoming* GW rather than the processed GW
- [ ] After merge + deploy: confirm fresh bootstrap + fixtures timestamps appear in `s3://fpl-data-lake-dev/raw/fpl-api/season=*/bootstrap/` and `/fixtures/` on each run

🤖 Generated with [Claude Code](https://claude.com/claude-code)