### PR TITLE
chore(infra): disable agent Lambda reserved concurrency until account quota raised

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Infra: agent Lambda `reserved_concurrent_executions = 10` temporarily commented out** in `infrastructure/environments/dev/lambda.tf`. The `fpl-dev` AWS account ships with a 10-concurrent-execution Lambda quota (new-account default; AWS standard is 1000), and AWS enforces `UnreservedConcurrentExecutions >= 10` — so reserving any concurrency on a single function fails `terraform apply` with `InvalidParameterValueException`. A Service Quotas case has been opened to raise the account quota to 1000; the reservation will be restored under #121 once approved. Until then the agent endpoint relies on the application-level RateLimiter + BudgetTracker for spam protection, with no infrastructure-level concurrency cap.
+
 ### Added
 - **Agent: `GET /team` endpoint** that fetches a user's FPL squad and returns it pre-enriched. Two-step under the hood — invoke the team-fetcher Lambda (raw FPL passthrough), then join against Neon `player_embeddings` for `web_name` / `team_name` / `price` so consumers don't need a separate name-resolution step. Returns `UserSquad` with money fields converted from FPL's tenths-of-millions wire format to whole pounds. Errors map to: 404 for unknown team_id, 502 for upstream failure (Lambda/FPL/Neon), 503 if `TEAM_FETCHER_FUNCTION_NAME` is unset. Wrapped with `@observe(name="get_team")` so squad-load failures land next to chat traces in the same Langfuse timeline.
 - **Agent: `UserSquad` + `SquadPick` Pydantic response models** (`models/responses.py`). Enriched shape with names + team + price; money in `float` £m, not the FPL API's tenths-of-millions integers. Conversion happens once at the loader boundary so both the agent's recommender and the dashboard read natural units.

--- a/docs/architecture/agent-architecture.md
+++ b/docs/architecture/agent-architecture.md
@@ -128,7 +128,7 @@ The agent endpoint is publicly accessible — anyone with the CloudFront URL can
 
 | Layer | Where | Configuration | Purpose |
 |-------|-------|---------------|---------|
-| Lambda reserved concurrency | Terraform (`modules/lambda`) | `reserved_concurrent_executions = 10` | Hardware-level backpressure; replaces API Gateway throttling after ADR-0010 |
+| Lambda reserved concurrency | Terraform (`modules/lambda`) | `reserved_concurrent_executions = 10` (currently disabled — see [#121](https://github.com/ikuzuki/fpl-platform/issues/121)) | Hardware-level backpressure; replaces API Gateway throttling after ADR-0010. Disabled until the AWS account's Lambda concurrency quota is raised from the new-account default of 10 |
 | Application rate limiter | `middleware/rate_limit.py` | 5/min + 20/hour per session | Per-session fairness; in-memory per Lambda container |
 | Reflector iteration cap | `graph/config.py` | `MAX_ITERATIONS = 3` | Bounds per-request LLM calls at 7 (3 planner + 3 reflector + 1 recommender). Most queries resolve in 2 iterations (5 calls) |
 | DynamoDB budget kill-switch | `fpl-agent-usage-dev` | Monthly `$5` cap enforced at request entry | Hard cap on monthly spend. Returns 429 "demo has hit its monthly limit" when exceeded |

--- a/docs/architecture/security-architecture.md
+++ b/docs/architecture/security-architecture.md
@@ -54,7 +54,9 @@ Automatic and free whenever traffic flows through CloudFront. Covers SYN floods,
 `AuthType = NONE`. Public by design. Never called directly in production — CloudFront is the only fronting origin. A future hardening step is moving to `AuthType = AWS_IAM` and signing requests from CloudFront via Origin Access Control; deferred until the endpoint is considered production.
 
 ### 4. Lambda reserved concurrency — infrastructure backpressure
-`reserved_concurrent_executions = 10` on the agent Lambda. When more than 10 requests are in-flight concurrently, Lambda itself returns 429 without invoking the function. This replaces API Gateway's endpoint throttling (removed per ADR-0010) with infrastructure-level enforcement.
+**Status: temporarily disabled — see [#121](https://github.com/ikuzuki/fpl-platform/issues/121).** The `fpl-dev` AWS account ships with the new-account default Lambda concurrency quota of `10` (the AWS default elsewhere is `1000`). AWS enforces `UnreservedConcurrentExecutions >= 10`, so reserving any concurrency on a single function fails with `InvalidParameterValueException`. A Service Quotas case has been opened to raise the account quota; the reservation will be restored once approved.
+
+When restored: `reserved_concurrent_executions = 10` on the agent Lambda. When more than 10 requests are in-flight concurrently, Lambda itself returns 429 without invoking the function. This replaces API Gateway's endpoint throttling (removed per ADR-0010) with infrastructure-level enforcement.
 
 Properties:
 - **Cap blast radius.** A 100-rps flood gets 10 concurrent Lambdas; the other 90 rps hit 429 without cost.

--- a/infrastructure/environments/dev/lambda.tf
+++ b/infrastructure/environments/dev/lambda.tf
@@ -208,7 +208,14 @@ module "lambda_agent" {
   # Hardware-level backpressure for the public agent endpoint. Replaces API
   # Gateway's 10rps/20-burst throttling after ADR-0010 removed API Gateway
   # from the agent stack. See docs/architecture/security-architecture.md.
-  reserved_concurrent_executions = 10
+  #
+  # TEMPORARILY DISABLED — see #121.
+  # The fpl-dev account ships with a 10-concurrent-execution Lambda quota
+  # (new-account default; AWS standard is 1000). AWS enforces
+  # UnreservedConcurrentExecutions >= 10, so reserving any concurrency on a
+  # single function fails with InvalidParameterValueException. Restore the
+  # line below once the Service Quotas case raises the account quota to 1000.
+  # reserved_concurrent_executions = 10
   environment_variables = {
     ENV                            = var.environment
     NEON_SECRET_ARN                = aws_secretsmanager_secret.neon_database_url.arn


### PR DESCRIPTION
## Summary

- Comment out `reserved_concurrent_executions = 10` on the agent Lambda in `infrastructure/environments/dev/lambda.tf` so `terraform apply` stops failing.
- Update `security-architecture.md` and `agent-architecture.md` to reflect the temporary disablement.
- Add CHANGELOG entry under `[Unreleased] / Changed`.

## Why

The `terraform apply` for #117 failed in CI with:

```
Error: setting Lambda Function (fpl-dev-agent) concurrency: operation error Lambda:
PutFunctionConcurrency, https response error StatusCode: 400,
InvalidParameterValueException: Specified ReservedConcurrentExecutions for function
decreases account's UnreservedConcurrentExecution below its minimum value of [10].
```

Root cause: the `fpl-dev` account has the new-account default Lambda concurrency quota of `10` (the AWS standard elsewhere is `1000`). AWS enforces `UnreservedConcurrentExecutions >= 10`, which means reserving *any* concurrency on a single function — even `1` — drops unreserved below the minimum and is rejected.

Verified with both APIs:

```bash
$ aws lambda get-account-settings --profile fpl-dev --region eu-west-2 \
    --query 'AccountLimit.[ConcurrentExecutions,UnreservedConcurrentExecutions]'
[10, 10]

$ aws service-quotas get-service-quota --service-code lambda \
    --quota-code L-B99A9384 --profile fpl-dev --region eu-west-2 \
    --query 'Quota.Value'
10.0
```

A Service Quotas case has been opened to raise the account quota from 10 to 1000.

## What about the spam protection?

The reservation existed specifically to prevent malicious users from spamming the agent's Function URL and burning Anthropic API budget — see [security-architecture.md §4](docs/architecture/security-architecture.md). While disabled, the agent endpoint still has:

- **Application `RateLimiter`** — 5 req/min, 20 req/hour per session
- **`BudgetTracker`** — hard `$5`/month cap, returns 429 when hit
- **Reflector iteration cap** — bounds per-request LLM calls at 7

What's missing until restoration: an infrastructure-level cap that prevents the function from being invoked at all under flood. The `BudgetTracker` is still the hard backstop on cost.

## Follow-up

Tracked in #121 — restore the line + revert the doc notes once the Service Quotas case is approved.

## Test plan

- [ ] CI `terraform plan` passes (no `PutFunctionConcurrency` change planned)
- [ ] `terraform apply` succeeds in dev
- [ ] Agent Lambda still deploys and `GET /health` returns 200 via CloudFront
- [ ] Lambda console shows the agent function with **no** reserved concurrency set
