### PR TITLE
docs: add personal site references

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Fantasy Premier League analytics platform that collects weekly player data, enriches it with AI-generated insights, and serves transfer recommendations.
 
-**[See it live](https://dxz2mzo798tf9.cloudfront.net/)** · Built with Python, Terraform, React, and Claude.
+**[See it live](https://dxz2mzo798tf9.cloudfront.net/)** · **[About the author](https://isseikuzuki.co.uk)** · Built with Python, Terraform, React, and Claude.
 
 ## Why this project exists
 
@@ -30,8 +30,7 @@ fpl-platform/
 │   └── agent/                  # LangGraph transfer recommendation agent
 │
 ├── web/
-│   ├── dashboard/              # React 19 + TypeScript + Tailwind v4
-│   └── portfolio/              # Static portfolio site
+│   └── dashboard/              # React 19 + TypeScript + Tailwind v4
 │
 ├── scripts/                    # Backfill and utility scripts
 ├── docs/adr/                   # Architecture Decision Records (7 ADRs)

--- a/web/dashboard/src/pages/AboutPage.tsx
+++ b/web/dashboard/src/pages/AboutPage.tsx
@@ -1,4 +1,4 @@
-import { ExternalLink, Mail } from "lucide-react";
+import { ExternalLink, Globe, Mail } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { PulseLogo } from "@/components/icons/FplIcons";
@@ -149,7 +149,17 @@ export function AboutPage() {
                   League obsession into a demonstration of production
                   engineering principles.
                 </p>
-                <div className="flex gap-3 mt-4">
+                <div className="flex gap-3 mt-4 flex-wrap">
+                  <a
+                    href="https://isseikuzuki.co.uk"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex items-center gap-1.5 text-sm text-[var(--muted-foreground)] hover:text-[var(--foreground)] transition-colors"
+                  >
+                    <Globe className="h-4 w-4" />
+                    Website
+                    <ExternalLink className="h-3 w-3" />
+                  </a>
                   <a
                     href="https://github.com/ikuzuki"
                     target="_blank"


### PR DESCRIPTION
## Summary
- Surface https://isseikuzuki.co.uk on the README (top metadata line, alongside the live dashboard link)
- Add Website link to the AboutPage social-links row in the dashboard (sits next to GitHub, LinkedIn, Contact)
- Remove stale `web/portfolio/` reference from the repo structure block — directory has been empty and is superseded by the personal site

## Test plan
- [x] README renders correctly on GitHub
- [x] AboutPage builds and the new Globe icon imports from lucide-react
- [x] All four social links (Website, GitHub, LinkedIn, Contact) display in the row, wrap cleanly on narrow viewports